### PR TITLE
Update Tambourine Voice intro to reflect contributor role

### DIFF
--- a/_posts/2026-02-12-tambourine-voice-code-deep-dive.md
+++ b/_posts/2026-02-12-tambourine-voice-code-deep-dive.md
@@ -12,7 +12,7 @@ tags:
 hidden: false
 ---
 
-I've been dictating a lot recently. Emails, Slack messages, notes, even commit messages. And the tool I keep reaching for is [Tambourine Voice](https://github.com/kstonekuan/tambourine-voice). It's an open source dictation app built by my friend [Kingston Kuan](https://github.com/kstonekuan), and I can't stop using it.
+I've been dictating a lot recently. Emails, Slack messages, notes, even commit messages. And the tool I keep reaching for is [Tambourine Voice](https://github.com/kstonekuan/tambourine-voice). It's an open source dictation app started by my friend [Kingston Kuan](https://github.com/kstonekuan), and I've been contributing to it as well. I can't stop using it.
 
 What got me interested wasn't just that it works well (it does), but that it's open source. You can pull up the code, see exactly how it processes your voice, and write your own prompt packs to teach it your vocabulary. That last part is what really hooked me. I went through the source code to understand why it feels so different from every other dictation tool I've tried, and I want to walk through what I found.
 


### PR DESCRIPTION
## Summary
Updated the introductory paragraph of the Tambourine Voice deep dive post to clarify the author's relationship with the project and acknowledge their contributions to it.

## Changes
- Changed "built by" to "started by" to more accurately reflect Kingston Kuan's role as the project initiator
- Added a sentence acknowledging the author's contributions to the project alongside their use of it
- Improved the narrative flow to better establish the author's credibility and investment in the tool

## Details
This change provides better context for readers about the author's perspective on the project. Rather than presenting themselves as merely a user of the tool, the updated text establishes that they are an active contributor, which strengthens their authority when discussing the codebase and implementation details in the subsequent deep dive.

https://claude.ai/code/session_01NkHZdLRn2tWXiB5LvAojRQ