### PR TITLE
Redesign site with warm editorial aesthetic

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,19 @@
+# Live things linked from the home page's "Things I build & run" section.
+# Fields: name, url (external or site-relative), blurb, optional note.
+- name: Story to Manga Machine
+  url: https://app.storytomanga.com
+  blurb: Paste a story, watch it become manga. Built in 48 hours across nine time zones.
+  note: with Kingston Kuan
+
+- name: Tambourine Voice
+  url: https://github.com/kstonekuan/tambourine-voice
+  blurb: Open-source dictation that actually gets your words right.
+  note: contributor
+
+- name: Pokemon TCG Event Day
+  url: /pokemon/
+  blurb: Rules, timers, and tools for the prerelease events I run.
+
+- name: TCG Idle Game
+  url: /tcg-idle-game/
+  blurb: An ASCII idle game — from casual collector to card shop owner.

--- a/_includes/font-includes.html
+++ b/_includes/font-includes.html
@@ -5,4 +5,4 @@ different fonts as applicable.
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Display&family=Libre+Caslon+Text:ital,wght@0,400;0,700;1,400&family=Libre+Franklin:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />

--- a/_includes/font-includes.html
+++ b/_includes/font-includes.html
@@ -1,7 +1,8 @@
-  
 {% comment %}
 Separate partial for Google Webfont include, so we can override with
 different fonts as applicable.
 {% endcomment %}
 
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Comfortaa" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />

--- a/_includes/font-includes.html
+++ b/_includes/font-includes.html
@@ -5,4 +5,4 @@ different fonts as applicable.
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Display&family=Libre+Caslon+Text:ital,wght@0,400;0,700;1,400&family=Libre+Franklin:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,0 +1,11 @@
+<div class="masthead-wrap">
+  <header class="masthead">
+    <a class="masthead-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <nav class="masthead-nav">
+      <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
+      {% include category-links.html %}
+      {% include page-links.html %}
+      <a href="{{ 'feed.xml' | relative_url }}">RSS</a>
+    </nav>
+  </header>
+</div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,15 +1,10 @@
-<header class="masthead">
-  <div class="nameplate">
-    <a class="nameplate-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
-    <p class="nameplate-dateline">
-      <span class="dateline-date">{{ site.time | date: "%A, %B %-d, %Y" }}</span>
-      <span class="dateline-sep" aria-hidden="true">&middot;</span>
-      <span class="dateline-tag">{{ site.description }}</span>
-    </p>
-  </div>
-  <nav class="section-bar">
-    <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
-    {% include category-links.html %}
-    {% include page-links.html %}
-  </nav>
-</header>
+<div class="masthead-wrap">
+  <header class="masthead">
+    <a class="masthead-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <nav class="masthead-nav">
+      <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
+      {% include category-links.html %}
+      {% include page-links.html %}
+    </nav>
+  </header>
+</div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,10 +1,15 @@
-<div class="masthead-wrap">
-  <header class="masthead">
-    <a class="masthead-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
-    <nav class="masthead-nav">
-      <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
-      {% include category-links.html %}
-      {% include page-links.html %}
-    </nav>
-  </header>
-</div>
+<header class="masthead">
+  <div class="nameplate">
+    <a class="nameplate-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <p class="nameplate-dateline">
+      <span class="dateline-date">{{ site.time | date: "%A, %B %-d, %Y" }}</span>
+      <span class="dateline-sep" aria-hidden="true">&middot;</span>
+      <span class="dateline-tag">{{ site.description }}</span>
+    </p>
+  </div>
+  <nav class="section-bar">
+    <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
+    {% include category-links.html %}
+    {% include page-links.html %}
+  </nav>
+</header>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,7 +5,6 @@
       <a class="{% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
       {% include category-links.html %}
       {% include page-links.html %}
-      <a href="{{ 'feed.xml' | relative_url }}">RSS</a>
     </nav>
   </header>
 </div>

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -1,5 +1,8 @@
 <div class="post-meta">
   <span class="post-date">{{ include.post.date | date_to_string }}</span>
+  {% assign words = include.post.content | number_of_words %}
+  {% assign minutes = words | divided_by: 200 | plus: 1 %}
+  <span class="post-reading">&bull; {{ minutes }} min read</span>
   <span class="post-categories">
     {% for category in include.post.categories %}
       &bull;

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -1,9 +1,32 @@
 <div class="post-meta">
-  <span class="post-byline">By {{ site.author.name }}</span>
-  <span class="meta-sep" aria-hidden="true">&middot;</span>
-  <span class="post-date">{{ include.post.date | date: "%B %-d, %Y" }}</span>
+  <span class="post-date">{{ include.post.date | date_to_string }}</span>
   {% assign words = include.post.content | number_of_words %}
   {% assign minutes = words | divided_by: 200 | plus: 1 %}
-  <span class="meta-sep" aria-hidden="true">&middot;</span>
-  <span class="post-reading">{{ minutes }} min read</span>
+  <span class="post-reading">&bull; {{ minutes }} min read</span>
+  <span class="post-categories">
+    {% for category in include.post.categories %}
+      &bull;
+
+      {% comment %}
+        Check if this category has a corresponding page before decide
+        to link to it. This is an O(n^2) operations so consider removing
+        it and linking for all categories (or no categories) if this
+        site has a lot of pages and/or a lot of categories.
+      {% endcomment %}
+      {% assign category_page = false %}
+      {% for node in site.pages %}
+        {% if node.category == category or node.title == category %}
+          {% assign category_page = node %}
+        {% endif %}
+      {% endfor %}
+
+      {% if category_page %}
+        <a href="{{ category_page.url | relative_url }}">
+          {{ category_page.title | default: category_page.category }}
+        </a>
+      {% else %}
+        {{ category }}
+      {% endif %}
+    {% endfor %}
+  </span>
 </div>

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -1,32 +1,9 @@
 <div class="post-meta">
-  <span class="post-date">{{ include.post.date | date_to_string }}</span>
+  <span class="post-byline">By {{ site.author.name }}</span>
+  <span class="meta-sep" aria-hidden="true">&middot;</span>
+  <span class="post-date">{{ include.post.date | date: "%B %-d, %Y" }}</span>
   {% assign words = include.post.content | number_of_words %}
   {% assign minutes = words | divided_by: 200 | plus: 1 %}
-  <span class="post-reading">&bull; {{ minutes }} min read</span>
-  <span class="post-categories">
-    {% for category in include.post.categories %}
-      &bull;
-
-      {% comment %}
-        Check if this category has a corresponding page before decide
-        to link to it. This is an O(n^2) operations so consider removing
-        it and linking for all categories (or no categories) if this
-        site has a lot of pages and/or a lot of categories.
-      {% endcomment %}
-      {% assign category_page = false %}
-      {% for node in site.pages %}
-        {% if node.category == category or node.title == category %}
-          {% assign category_page = node %}
-        {% endif %}
-      {% endfor %}
-
-      {% if category_page %}
-        <a href="{{ category_page.url | relative_url }}">
-          {{ category_page.title | default: category_page.category }}
-        </a>
-      {% else %}
-        {{ category }}
-      {% endif %}
-    {% endfor %}
-  </span>
+  <span class="meta-sep" aria-hidden="true">&middot;</span>
+  <span class="post-reading">{{ minutes }} min read</span>
 </div>

--- a/_includes/post-nav.html
+++ b/_includes/post-nav.html
@@ -1,0 +1,35 @@
+{% comment %}
+  Older/newer navigation between visible posts. Jekyll's built-in
+  page.previous/page.next would surface posts marked `hidden: true`,
+  so neighbors are computed against the filtered list instead.
+{% endcomment %}
+{% assign visible = site.posts | where_exp: "p", "p.hidden != true" %}
+{% for p in visible %}
+  {% if p.url == page.url %}
+    {% if forloop.index0 > 0 %}
+      {% assign newer_i = forloop.index0 | minus: 1 %}
+      {% assign newer = visible[newer_i] %}
+    {% endif %}
+    {% unless forloop.last %}
+      {% assign older_i = forloop.index0 | plus: 1 %}
+      {% assign older = visible[older_i] %}
+    {% endunless %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+{% if older or newer %}
+<nav class="post-nav" aria-label="Post navigation">
+  {% if older %}
+    <a class="post-nav-item post-nav-older" href="{{ older.url | relative_url }}">
+      <span class="post-nav-label">Older</span>
+      <span class="post-nav-title">{{ older.title }}</span>
+    </a>
+  {% endif %}
+  {% if newer %}
+    <a class="post-nav-item post-nav-newer" href="{{ newer.url | relative_url }}">
+      <span class="post-nav-label">Newer</span>
+      <span class="post-nav-title">{{ newer.title }}</span>
+    </a>
+  {% endif %}
+</nav>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,11 +12,6 @@
     </main>
 
     <footer class="site-footer">
-      <p class="footer-note">
-        Written between Singapore and Seattle. If something here caught your eye,
-        <a href="mailto:{{ site.email }}">send me a note</a> &mdash; strongly worded
-        emails welcome too.
-      </p>
       <p class="footer-links">
         <a href="mailto:{{ site.email }}">Email</a> &middot;
         <a href="https://github.com/{{ site.author.github }}">GitHub</a> &middot;
@@ -26,7 +21,6 @@
         <a href="{{ tags_page.url | relative_url }}">Tags</a>
         {%- endif %}
       </p>
-      <p class="footer-colophon">Set in Fraunces &amp; Source Serif.</p>
       {% include copyright.html %}
     </footer>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,11 @@
     </main>
 
     <footer class="site-footer">
+      <p class="footer-note">
+        Written between Singapore and Seattle. If something here caught your eye,
+        <a href="mailto:{{ site.email }}">send me a note</a> &mdash; strongly worded
+        emails welcome too.
+      </p>
       <p class="footer-links">
         <a href="mailto:{{ site.email }}">Email</a> &middot;
         <a href="https://github.com/{{ site.author.github }}">GitHub</a> &middot;
@@ -21,6 +26,7 @@
         <a href="{{ tags_page.url | relative_url }}">Tags</a>
         {%- endif %}
       </p>
+      <p class="footer-colophon">Set in Fraunces &amp; Source Serif.</p>
       {% include copyright.html %}
     </footer>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,24 @@
 
   <body class="{{ page.layout }}{% if page.url == '/' %} home{% endif %}">
 
-    {% include sidebar.html %}
+    {% include masthead.html %}
 
     <main class="container">
       {{ content }}
     </main>
+
+    <footer class="site-footer">
+      <p class="footer-links">
+        <a href="mailto:{{ site.email }}">Email</a> &middot;
+        <a href="https://github.com/{{ site.author.github }}">GitHub</a> &middot;
+        <a href="{{ site.author.url }}">LinkedIn</a>
+        {%- assign tags_page = site.pages | where: "layout", "tags" | first -%}
+        {%- if tags_page %} &middot;
+        <a href="{{ tags_page.url | relative_url }}">Tags</a>
+        {%- endif %}
+      </p>
+      {% include copyright.html %}
+    </footer>
 
     {% include custom-foot.html %}
   </body>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -3,6 +3,13 @@ layout: default
 ---
 
 <div class="content">
+  {% if page.url == "/" %}
+    <section class="home-intro">
+      <h1>{{ site.description }}</h1>
+      <p class="home-tagline">{{ site.tagline }}</p>
+    </section>
+  {% endif %}
+
   {% include pagination-newer.html %}
 
   {{ content }}
@@ -11,23 +18,17 @@ layout: default
     {% for post in paginator.posts %}
       {% if post.hidden %}{% continue %}{% endif %}
       <article class="home-post">
-        <div class="home-post-meta">
-          <small>{{ post.date | date_to_string }}</small>
+        <div class="entry-meta">
+          {% assign category = post.categories | first %}
+          {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
+          <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
         </div>
-        <div class="home-post-content">
-          <h3>
-            <a href="{{ post.url | relative_url }}">
-              {{ post.title }}
-            </a>
-          </h3>
-          {% if post.excerpt %}
-            <div class="home-post-excerpt">
-              <a href="{{ post.url | relative_url }}">
-                {{ post.excerpt | strip_html | truncatewords: 25 }}
-              </a>
-            </div>
-          {% endif %}
-        </div>
+        <h2 class="entry-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </h2>
+        {% if post.excerpt %}
+          <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
+        {% endif %}
       </article>
     {% endfor %}
   </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -5,9 +5,11 @@ layout: default
 <div class="content">
   {% if page.url == "/" %}
     <section class="home-intro">
+      <p class="home-kicker">Field Notes</p>
       <h1>{{ site.description }}</h1>
       <p class="home-tagline">{{ site.tagline }}</p>
     </section>
+    <div class="ornament" aria-hidden="true">&#10087;</div>
   {% endif %}
 
   {% include pagination-newer.html %}
@@ -17,18 +19,24 @@ layout: default
   <div class="home-posts">
     {% for post in paginator.posts %}
       {% if post.hidden %}{% continue %}{% endif %}
-      <article class="home-post">
-        <div class="entry-meta">
-          {% assign category = post.categories | first %}
-          {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
-          <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      {% assign is_lead = false %}
+      {% if forloop.first and paginator.page == 1 %}{% assign is_lead = true %}{% endif %}
+      <article class="home-post{% if is_lead %} is-lead{% endif %}">
+        <span class="entry-index" aria-hidden="true">{{ forloop.index | prepend: '0' | slice: -2, 2 }}</span>
+        <div class="entry-body">
+          <div class="entry-meta">
+            {% if is_lead %}<span class="entry-flag">Latest</span>{% endif %}
+            {% assign category = post.categories | first %}
+            {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
+            <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+          </div>
+          <h2 class="entry-title">
+            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+          </h2>
+          {% if post.excerpt %}
+            <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
+          {% endif %}
         </div>
-        <h2 class="entry-title">
-          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        </h2>
-        {% if post.excerpt %}
-          <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
-        {% endif %}
       </article>
     {% endfor %}
   </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -3,29 +3,40 @@ layout: default
 ---
 
 <div class="content">
+  {% if page.url == "/" %}
+    <section class="home-intro">
+      <p class="home-kicker">Field Notes</p>
+      <h1>{{ site.description }}</h1>
+      <p class="home-tagline">{{ site.tagline }}</p>
+    </section>
+    <div class="ornament" aria-hidden="true">&#10087;</div>
+  {% endif %}
+
   {% include pagination-newer.html %}
 
   {{ content }}
 
-  <div class="story-list">
+  <div class="home-posts">
     {% for post in paginator.posts %}
       {% if post.hidden %}{% continue %}{% endif %}
       {% assign is_lead = false %}
       {% if forloop.first and paginator.page == 1 %}{% assign is_lead = true %}{% endif %}
-      <article class="story{% if is_lead %} story--lead{% endif %}">
-        {% assign category = post.categories | first %}
-        {% if category %}<p class="story-kicker">{{ category }}</p>{% endif %}
-        <h2 class="story-headline">
-          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        </h2>
-        {% if post.excerpt %}
-          <p class="story-deck">{{ post.excerpt | strip_html | truncatewords: 36 }}</p>
-        {% endif %}
-        <p class="story-byline">
-          By {{ site.author.name }}
-          <span class="byline-sep" aria-hidden="true">&middot;</span>
-          {{ post.date | date: "%b %-d, %Y" }}
-        </p>
+      <article class="home-post{% if is_lead %} is-lead{% endif %}">
+        <span class="entry-index" aria-hidden="true">{{ forloop.index | prepend: '0' | slice: -2, 2 }}</span>
+        <div class="entry-body">
+          <div class="entry-meta">
+            {% if is_lead %}<span class="entry-flag">Latest</span>{% endif %}
+            {% assign category = post.categories | first %}
+            {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
+            <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+          </div>
+          <h2 class="entry-title">
+            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+          </h2>
+          {% if post.excerpt %}
+            <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
+          {% endif %}
+        </div>
       </article>
     {% endfor %}
   </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -3,40 +3,29 @@ layout: default
 ---
 
 <div class="content">
-  {% if page.url == "/" %}
-    <section class="home-intro">
-      <p class="home-kicker">Field Notes</p>
-      <h1>{{ site.description }}</h1>
-      <p class="home-tagline">{{ site.tagline }}</p>
-    </section>
-    <div class="ornament" aria-hidden="true">&#10087;</div>
-  {% endif %}
-
   {% include pagination-newer.html %}
 
   {{ content }}
 
-  <div class="home-posts">
+  <div class="story-list">
     {% for post in paginator.posts %}
       {% if post.hidden %}{% continue %}{% endif %}
       {% assign is_lead = false %}
       {% if forloop.first and paginator.page == 1 %}{% assign is_lead = true %}{% endif %}
-      <article class="home-post{% if is_lead %} is-lead{% endif %}">
-        <span class="entry-index" aria-hidden="true">{{ forloop.index | prepend: '0' | slice: -2, 2 }}</span>
-        <div class="entry-body">
-          <div class="entry-meta">
-            {% if is_lead %}<span class="entry-flag">Latest</span>{% endif %}
-            {% assign category = post.categories | first %}
-            {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
-            <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-          </div>
-          <h2 class="entry-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-          {% if post.excerpt %}
-            <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
-          {% endif %}
-        </div>
+      <article class="story{% if is_lead %} story--lead{% endif %}">
+        {% assign category = post.categories | first %}
+        {% if category %}<p class="story-kicker">{{ category }}</p>{% endif %}
+        <h2 class="story-headline">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </h2>
+        {% if post.excerpt %}
+          <p class="story-deck">{{ post.excerpt | strip_html | truncatewords: 36 }}</p>
+        {% endif %}
+        <p class="story-byline">
+          By {{ site.author.name }}
+          <span class="byline-sep" aria-hidden="true">&middot;</span>
+          {{ post.date | date: "%b %-d, %Y" }}
+        </p>
       </article>
     {% endfor %}
   </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -8,11 +8,30 @@ layout: default
       <h1>{{ site.description }}</h1>
       <p class="home-tagline">{{ site.tagline }}</p>
     </section>
+
+    {% if site.data.projects %}
+      <section class="home-projects">
+        <h2 class="home-section-title">Things I build &amp; run</h2>
+        <ul class="projects-list">
+          {% for project in site.data.projects %}
+            <li>
+              <a href="{% if project.url contains '://' %}{{ project.url }}{% else %}{{ project.url | relative_url }}{% endif %}">{{ project.name }}</a>
+              <span class="project-blurb">{{ project.blurb }}</span>
+              {% if project.note %}<span class="project-note">{{ project.note }}</span>{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
   {% endif %}
 
   {% include pagination-newer.html %}
 
   {{ content }}
+
+  {% if page.url == "/" %}
+    <h2 class="home-section-title">Writing</h2>
+  {% endif %}
 
   <div class="home-posts">
     {% for post in paginator.posts %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -5,11 +5,9 @@ layout: default
 <div class="content">
   {% if page.url == "/" %}
     <section class="home-intro">
-      <p class="home-kicker">Field Notes</p>
       <h1>{{ site.description }}</h1>
       <p class="home-tagline">{{ site.tagline }}</p>
     </section>
-    <div class="ornament" aria-hidden="true">&#10087;</div>
   {% endif %}
 
   {% include pagination-newer.html %}
@@ -19,24 +17,18 @@ layout: default
   <div class="home-posts">
     {% for post in paginator.posts %}
       {% if post.hidden %}{% continue %}{% endif %}
-      {% assign is_lead = false %}
-      {% if forloop.first and paginator.page == 1 %}{% assign is_lead = true %}{% endif %}
-      <article class="home-post{% if is_lead %} is-lead{% endif %}">
-        <span class="entry-index" aria-hidden="true">{{ forloop.index | prepend: '0' | slice: -2, 2 }}</span>
-        <div class="entry-body">
-          <div class="entry-meta">
-            {% if is_lead %}<span class="entry-flag">Latest</span>{% endif %}
-            {% assign category = post.categories | first %}
-            {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
-            <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-          </div>
-          <h2 class="entry-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-          {% if post.excerpt %}
-            <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
-          {% endif %}
+      <article class="home-post">
+        <div class="entry-meta">
+          {% assign category = post.categories | first %}
+          {% if category %}<span class="entry-category">{{ category }}</span> &middot; {% endif %}
+          <span class="entry-date">{{ post.date | date: "%b %-d, %Y" }}</span>
         </div>
+        <h2 class="entry-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </h2>
+        {% if post.excerpt %}
+          <p class="entry-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
+        {% endif %}
       </article>
     {% endfor %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,7 @@ layout: default
     {{ content }}
     {% include post-tags.html post=page %}
   </div>
+  {% include post-nav.html %}
   {% include comments.html %}
   {% include related_posts.html %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,15 +2,13 @@
 layout: default
 ---
 
-<header class="post-head">
-  {% assign category = page.categories | first %}
-  {% if category %}<p class="story-kicker">{{ category }}</p>{% endif %}
+<header>
   <h1 class="post-title">{{ page.title }}</h1>
 </header>
 <div class="content">
   {% include post-meta.html post=page %}
 
-  <div class="post-body">
+  <div class="post-body{% unless page.dropcap == false %} dropcap{% endunless %}">
     {{ content }}
     {% include post-tags.html post=page %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 <div class="content">
   {% include post-meta.html post=page %}
 
-  <div class="post-body{% unless page.dropcap == false %} dropcap{% endunless %}">
+  <div class="post-body">
     {{ content }}
     {% include post-tags.html post=page %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,13 +2,15 @@
 layout: default
 ---
 
-<header>
+<header class="post-head">
+  {% assign category = page.categories | first %}
+  {% if category %}<p class="story-kicker">{{ category }}</p>{% endif %}
   <h1 class="post-title">{{ page.title }}</h1>
 </header>
 <div class="content">
   {% include post-meta.html post=page %}
 
-  <div class="post-body{% unless page.dropcap == false %} dropcap{% endunless %}">
+  <div class="post-body">
     {{ content }}
     {% include post-tags.html post=page %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 <div class="content">
   {% include post-meta.html post=page %}
 
-  <div class="post-body">
+  <div class="post-body{% unless page.dropcap == false %} dropcap{% endunless %}">
     {{ content }}
     {% include post-tags.html post=page %}
   </div>

--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -36,6 +36,7 @@ section {
 a {
   color: $link-color;
   text-decoration: none;
+  text-underline-offset: 2px;
 
   // `:focus` is linked to `:hover` for basic accessibility
   &:hover,
@@ -49,7 +50,7 @@ a {
 }
 
 img {
-  border-radius: 5px;
+  border-radius: $border-radius;
   display: block;
   height: auto; // prevent max-width from squishing images with defined height
   margin: 0 0 1rem;
@@ -71,6 +72,7 @@ th {
 }
 
 th {
+  background-color: $wash-strong;
   text-align: left;
 }
 

--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -14,7 +14,6 @@ body {
 
 html {
   font-family: $root-font-family;
-  font-feature-settings: 'onum' 1, 'kern' 1; // old-style figures + kerning
   font-size: $root-font-size;
   line-height: $root-line-height;
 

--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -14,6 +14,7 @@ body {
 
 html {
   font-family: $root-font-family;
+  font-feature-settings: 'onum' 1, 'kern' 1; // old-style figures + kerning
   font-size: $root-font-size;
   line-height: $root-line-height;
 

--- a/_sass/hydeout/_code.scss
+++ b/_sass/hydeout/_code.scss
@@ -1,7 +1,7 @@
 // Code
 //
-// Inline and block-level code snippets. Includes tweaks to syntax highlighted
-// snippets from Pygments/Rouge and Gist embeds.
+// Inline and block-level code snippets. Light, warm-toned treatment that
+// keeps the vendored Pygments/Rouge light syntax theme readable.
 
 code,
 pre {
@@ -9,18 +9,23 @@ pre {
 }
 
 code {
-  background-color: #f9f9f9;
-  border-radius: 3px;
+  background-color: #f1e9dc;
+  border-radius: 4px;
   color: $code-color;
   font-size: 85%;
-  padding: 0.25em 0.5em;
+  padding: 0.15em 0.4em;
 }
 
 pre {
+  background-color: $wash;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+  line-height: 1.5;
   margin-bottom: 1rem;
   margin-top: 0;
   max-width: 100%;
   overflow-x: auto;
+  padding: 1rem 1.25rem;
 }
 
 pre code {
@@ -32,45 +37,27 @@ pre code {
 
 // Pygments/Rouge via Jekyll
 .highlight {
-  background-color: #f9f9f9;
-  border-radius: 0.25rem;
-  font-size: 0.8rem;
-  line-height: 1.4;
+  background-color: $wash;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+  font-size: 0.85rem;
+  line-height: 1.5;
   margin-bottom: 1rem;
-  padding: 1rem;
+  padding: 1rem 1.25rem;
 
   pre {
+    background-color: transparent;
+    border: 0;
     margin-bottom: 0;
     overflow-x: auto;
+    padding: 0;
   }
 
   .lineno {
-    color: #999;
+    color: $body-muted;
     display: inline-block; // Ensures the null space also isn't selectable
     padding-left: 0.25rem;
     padding-right: 0.75rem;
     user-select: none; // Make sure numbers aren't selectable
   }
 }
-
-// Gist via GitHub Pages
-// .gist .gist-file {
-//   font-family: Menlo, Monaco, "Courier New", monospace !important;
-// }
-// .gist .markdown-body {
-//   padding: 15px;
-// }
-// .gist pre {
-//   padding: 0;
-//   background-color: transparent;
-// }
-// .gist .gist-file .gist-data {
-//   font-size: .8rem !important;
-//   line-height: 1.4;
-// }
-// .gist code {
-//   padding: 0;
-//   color: inherit;
-//   background-color: transparent;
-//   border-radius: 0;
-// }

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -1,335 +1,86 @@
 /*
   Layout
 
-  Styles for managing the structural hierarchy of the site.
-  Hydeout features the large colored sidebar from Hyde that houses the
-  site name, intro, and "footer" content. Sidebar is on top of content on
-  mobile and expands into sidebar on larger width displays.
-
-  Sidebar CSS assumes HTML looks like this for post pages:
+  Warm editorial layout: a slim masthead across the top of the page
+  (see _masthead.scss) and a single centered column of content beneath it.
 
     body
-    > #sidebar
-      > header (primary sidebar content -- i.e. title)
-        > h1 (home page only, otherwise div or span)
-      > secondary nav content we may want to hide on certain pages
+    > .masthead-wrap
+      > header.masthead
     > .container
-      > h1 (non-home page)
+      > header (post/page title, outside .content)
       > .content
-
-  Basic approach is to color in body, make sidebar background transparent,
-  and then fill in the .container or .content elements depending on how far
-  we want the sidebar or header to stretch.
+    > footer.site-footer
 */
 
 body {
-  background-attachment: fixed;
-  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
-  color: $sidebar-text-color;
-  display: flex;
-  flex-direction: column;
+  background: $body-bg;
+  color: $body-color;
   min-height: 100vh;
 }
 
-#sidebar {
-  flex: 0 0 auto;
-  padding: $section-spacing;
-
-  .site-title {
-    font-family: 'Abril Fatface', serif;
-    font-size: $large-font-size;
-    font-weight: normal;
-    margin-bottom: $heading-spacing;
-    margin-top: 0;
-  }
-
-  .site-title .back-arrow { margin-right: 0.5rem; }
-}
-
-.content {
-  background: $body-bg;
-  color: $body-color;
-  padding: $section-spacing;
-}
-
-// Container is flexbox as well -- we want content div to stretch and fill
 .container {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
+  margin: 0 auto;
+  max-width: $measure;
+  padding: 2rem 1.25rem 3rem;
 
-  > .content {
-    flex-grow: 1;
-    padding-bottom: $section-spacing * 2;
+  @media (min-width: $large-breakpoint) {
+    padding: 3rem 1.5rem 4rem;
   }
 }
 
-/* -----------------------------------------------------------
-  Mobile view
------------------------------------------------------------ */
-
-// Hide secondary nav content in sidebar
-// Hide lead paragraph in sidebar
-#sidebar {
-  header ~ *,
-  header ~ nav,
-  p.lead {
-    display: none;
-  }
-}
-
-// Make header elements blend into sidebar / background
+// Post and page titles render inside .container > header, outside .content
 .container > header {
-  background: transparent;
-  color: $sidebar-title-color;
-  margin:
-    ($heading-spacing - $section-spacing)
-    $section-spacing
-    $section-spacing;
+  margin-bottom: 1.5rem;
 
   h1,
   h2 {
-    color: inherit;
-  }
+    color: $heading-color;
+    font-family: $display-font-family;
+    font-size: 2.25rem;
+    line-height: 1.15;
+    margin: 0;
 
-  h1:last-child,
-  h2:last-child {
-    margin-bottom: 0;
+    @media (min-width: $large-breakpoint) {
+      font-size: 2.5rem;
+    }
   }
 }
 
-/* -----------------------------------------------------------
-  Mobile view for home page)
------------------------------------------------------------ */
-
-.home #sidebar {
-
-  // Center sidebar content
+.site-footer {
+  border-top: 1px solid $border-color;
+  color: $body-muted;
+  font-size: 0.8rem;
+  margin: 0 auto;
+  max-width: $masthead-width;
+  padding: 1.5rem;
   text-align: center;
 
-  // Bigger title
-  .site-title {
-    font-size: 2.5rem;
+  p {
+    margin: 0.25rem 0;
   }
 
-  // Show secondary nav content + lead
-  header ~ *,
-  p.lead {
-    display: block;
-  }
+  a {
+    color: $body-muted;
 
-  header ~ nav {
-    display: flex;
-  }
-
-  // Slightly more bottom padding to compensate for heading not match 100% of
-  // line-height on top
-  > *:last-child {
-    margin-bottom: 0.5rem;
-  }
-}
-
-/* -----------------------------------------------------------
-  Tablet / Desktop view
------------------------------------------------------------ */
-
-@media (min-width: $large-breakpoint) {
-  body {
-    flex-direction: row;
-    min-height: 100vh;
-    -webkit-overflow-scrolling: touch;
-    overflow-y: auto;
-
-    > * {
-      -webkit-overflow-scrolling: touch;
-      overflow-y: auto;
+    &:hover,
+    &:focus {
+      color: $link-color;
     }
   }
 
-  /* Undo mobile CSS */
-
-  #sidebar,
-  .home #sidebar {
-    text-align: left;
-    width: $sidebar-width;
-
-    > *:last-child {
-      margin-bottom: 0;
-    }
+  .footer-links a {
+    margin: 0 0.35rem;
   }
-
-  #sidebar {
-    position: fixed;
-
-    // Attach to bottom or top of window
-    @if $sidebar-sticky {
-      bottom: 0;
-    }
-
-    @else {
-      top: 0;
-    }
-
-    // Attach to right or left of window
-    @if $layout-reverse {
-      right: 0;
-    }
-
-    @else {
-      left: 0;
-    }
-
-    .site-title {
-      font-size: 1.5rem;
-      .back-arrow { display: none; }
-    }
-
-    p.lead,
-    header ~ * {
-      display: block;
-    }
-
-    header ~ nav {
-      display: flex;
-    }
-  }
-
-  .index #sidebar { margin-bottom: 0; }
-
-  // Make entire container background white to contrast against sidebar
-  .container {
-    background: $body-bg;
-    color: $body-color;
-    min-height: 100vh;
-    padding:
-      $section-spacing * 2
-      $section-spacing * 2
-      0;
-
-    @if $layout-reverse {
-      margin-right: $sidebar-width;
-    }
-
-    @else {
-      margin-left: $sidebar-width;
-    }
-
-    > header {
-      color: $heading-color;
-      margin: 0;
-
-      h1,
-      h2 {
-        color: inherit;
-
-        &:last-child {
-          margin-bottom: $heading-spacing;
-        }
-      }
-    }
-
-    > * {
-      max-width: 38rem;
-      padding: 0;
-    }
-  }
-}
-
-/* -----------------------------------------------------------
-  Sidebar links + nav
------------------------------------------------------------ */
-
-#sidebar a {
-  color: $sidebar-link-color;
-
-  svg {
-    fill: $sidebar-icon-color;
-  }
-}
-
-#sidebar a:hover,
-#sidebar a:focus,
-#sidebar a.active {
-  svg { fill: $sidebar-icon-color; }
-}
-
-#sidebar a:hover,
-#sidebar a:focus {
-  text-decoration: underline;
-
-  &.icon {
-    text-decoration: none;
-  }
-}
-
-#sidebar a.active {
-  font-weight: bold;
-}
-
-#sidebar .site-title {
-  color: $sidebar-title-color;
-  a { color: inherit; }
-}
-
-#sidebar nav {
-  display: flex;
-}
-
-#sidebar-nav-links {
-  flex-flow: column nowrap;
-}
-
-@media only screen and (max-width: 600px) {
-  #sidebar-nav-links {
-      flex-flow: row nowrap;
-      justify-content: space-around;
-  }
-}
-
-#sidebar-icon-links {
-  flex-flow: row wrap;
-  justify-content: center;
-  margin-top: 1rem;
-  max-width: 100%;
-
-  @media (min-width: $large-breakpoint) {
-    justify-content: flex-start;
-    margin-left: -0.25em;
-  }
-}
-
-#sidebar nav > * {
-  display: block;
-  line-height: 1.75;
-}
-
-#sidebar nav > .icon {
-  display: inline-block;
-  font-size: 1.5rem;
-  margin: 0 0.25em;
 }
 
 @media print {
-  #sidebar {
+  .masthead-wrap,
+  .site-footer {
     display: none;
   }
 
   body {
-    display: block;
-  }
-
-  .container {
-    display: block;
-    margin-left: 0;
-    margin-right: 0;
-    padding: 0;
-
-    > * {
-      max-width: 100%;
-    }
-  }
-
-  html {
-    font-size: normal;
+    background: #fff;
   }
 }

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -14,9 +14,34 @@
 */
 
 body {
-  background: $body-bg;
+  background-color: $body-bg;
+  // Barely-there print grain for tactile warmth (monochrome feTurbulence)
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
   color: $body-color;
   min-height: 100vh;
+}
+
+// Gentle rise-in on the main reading column
+.content {
+  animation: rise-in 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.6rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    animation: none;
+  }
 }
 
 .container {
@@ -44,6 +69,16 @@ body {
     @media (min-width: $large-breakpoint) {
       font-size: 2.5rem;
     }
+  }
+
+  // Short accent rule beneath post/page titles
+  &::after {
+    background: $link-color;
+    content: '';
+    display: block;
+    height: 2px;
+    margin-top: 1.1rem;
+    width: 2.5rem;
   }
 }
 

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -1,11 +1,12 @@
 /*
   Layout
 
-  Broadsheet layout: a centered nameplate + ruled section bar across the top
-  (see _masthead.scss) and a single column of content beneath it.
+  Warm editorial layout: a slim masthead across the top of the page
+  (see _masthead.scss) and a single centered column of content beneath it.
 
     body
-    > header.masthead
+    > .masthead-wrap
+      > header.masthead
     > .container
       > header (post/page title, outside .content)
       > .content
@@ -14,14 +15,45 @@
 
 body {
   background-color: $body-bg;
+  // Layered, intentionally subtle: a soft light glow up top and a faint warm
+  // wash at the foot give the paper depth, over a barely-there print grain
+  // (monochrome feTurbulence). No visible pattern -- just tactility.
+  background-image:
+    radial-gradient(115% 70% at 50% -12%, rgba(255, 252, 246, 0.85), rgba(255, 252, 246, 0) 55%),
+    radial-gradient(90% 50% at 50% 100%, rgba(178, 60, 10, 0.045), rgba(178, 60, 10, 0) 72%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+  background-repeat: no-repeat, no-repeat, repeat;
   color: $body-color;
   min-height: 100vh;
+}
+
+// Gentle rise-in on the main reading column
+.content {
+  animation: rise-in 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.6rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    animation: none;
+  }
 }
 
 .container {
   margin: 0 auto;
   max-width: $measure;
-  padding: 2.5rem 1.25rem 3rem;
+  padding: 2rem 1.25rem 3rem;
 
   @media (min-width: $large-breakpoint) {
     padding: 3rem 1.5rem 4rem;
@@ -30,27 +62,30 @@ body {
 
 // Post and page titles render inside .container > header, outside .content
 .container > header {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
 
   h1,
   h2 {
     color: $heading-color;
     font-family: $display-font-family;
-    font-size: 2.1rem;
-    font-weight: 700;
-    line-height: 1.12;
+    font-size: 2.25rem;
+    line-height: 1.15;
     margin: 0;
 
     @media (min-width: $large-breakpoint) {
-      font-size: 2.6rem;
+      font-size: 2.5rem;
     }
   }
-}
 
-// Post header: section kicker sits above the headline
-.post-head {
-  border-bottom: 1px solid $hairline;
-  padding-bottom: 1.25rem;
+  // Short accent rule beneath post/page titles
+  &::after {
+    background: $link-color;
+    content: '';
+    display: block;
+    height: 2px;
+    margin-top: 1.1rem;
+    width: 2.5rem;
+  }
 }
 
 .site-footer {
@@ -81,7 +116,7 @@ body {
 }
 
 @media print {
-  .masthead,
+  .masthead-wrap,
   .site-footer {
     display: none;
   }

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -1,12 +1,11 @@
 /*
   Layout
 
-  Warm editorial layout: a slim masthead across the top of the page
-  (see _masthead.scss) and a single centered column of content beneath it.
+  Broadsheet layout: a centered nameplate + ruled section bar across the top
+  (see _masthead.scss) and a single column of content beneath it.
 
     body
-    > .masthead-wrap
-      > header.masthead
+    > header.masthead
     > .container
       > header (post/page title, outside .content)
       > .content
@@ -15,45 +14,14 @@
 
 body {
   background-color: $body-bg;
-  // Layered, intentionally subtle: a soft light glow up top and a faint warm
-  // wash at the foot give the paper depth, over a barely-there print grain
-  // (monochrome feTurbulence). No visible pattern -- just tactility.
-  background-image:
-    radial-gradient(115% 70% at 50% -12%, rgba(255, 252, 246, 0.85), rgba(255, 252, 246, 0) 55%),
-    radial-gradient(90% 50% at 50% 100%, rgba(178, 60, 10, 0.045), rgba(178, 60, 10, 0) 72%),
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
-  background-repeat: no-repeat, no-repeat, repeat;
   color: $body-color;
   min-height: 100vh;
-}
-
-// Gentle rise-in on the main reading column
-.content {
-  animation: rise-in 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both;
-}
-
-@keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(0.6rem);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .content {
-    animation: none;
-  }
 }
 
 .container {
   margin: 0 auto;
   max-width: $measure;
-  padding: 2rem 1.25rem 3rem;
+  padding: 2.5rem 1.25rem 3rem;
 
   @media (min-width: $large-breakpoint) {
     padding: 3rem 1.5rem 4rem;
@@ -62,30 +30,27 @@ body {
 
 // Post and page titles render inside .container > header, outside .content
 .container > header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 
   h1,
   h2 {
     color: $heading-color;
     font-family: $display-font-family;
-    font-size: 2.25rem;
-    line-height: 1.15;
+    font-size: 2.1rem;
+    font-weight: 700;
+    line-height: 1.12;
     margin: 0;
 
     @media (min-width: $large-breakpoint) {
-      font-size: 2.5rem;
+      font-size: 2.6rem;
     }
   }
+}
 
-  // Short accent rule beneath post/page titles
-  &::after {
-    background: $link-color;
-    content: '';
-    display: block;
-    height: 2px;
-    margin-top: 1.1rem;
-    width: 2.5rem;
-  }
+// Post header: section kicker sits above the headline
+.post-head {
+  border-bottom: 1px solid $hairline;
+  padding-bottom: 1.25rem;
 }
 
 .site-footer {
@@ -116,7 +81,7 @@ body {
 }
 
 @media print {
-  .masthead-wrap,
+  .masthead,
   .site-footer {
     display: none;
   }

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -15,8 +15,14 @@
 
 body {
   background-color: $body-bg;
-  // Barely-there print grain for tactile warmth (monochrome feTurbulence)
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+  // Layered, intentionally subtle: a soft light glow up top and a faint warm
+  // wash at the foot give the paper depth, over a barely-there print grain
+  // (monochrome feTurbulence). No visible pattern -- just tactility.
+  background-image:
+    radial-gradient(115% 70% at 50% -12%, rgba(255, 252, 246, 0.85), rgba(255, 252, 246, 0) 55%),
+    radial-gradient(90% 50% at 50% 100%, rgba(178, 60, 10, 0.045), rgba(178, 60, 10, 0) 72%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+  background-repeat: no-repeat, no-repeat, repeat;
   color: $body-color;
   min-height: 100vh;
 }

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -15,39 +15,8 @@
 
 body {
   background-color: $body-bg;
-  // Layered, intentionally subtle: a soft light glow up top and a faint warm
-  // wash at the foot give the paper depth, over a barely-there print grain
-  // (monochrome feTurbulence). No visible pattern -- just tactility.
-  background-image:
-    radial-gradient(115% 70% at 50% -12%, rgba(255, 252, 246, 0.85), rgba(255, 252, 246, 0) 55%),
-    radial-gradient(90% 50% at 50% 100%, rgba(178, 60, 10, 0.045), rgba(178, 60, 10, 0) 72%),
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
-  background-repeat: no-repeat, no-repeat, repeat;
   color: $body-color;
   min-height: 100vh;
-}
-
-// Gentle rise-in on the main reading column
-.content {
-  animation: rise-in 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both;
-}
-
-@keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(0.6rem);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .content {
-    animation: none;
-  }
 }
 
 .container {
@@ -75,16 +44,6 @@ body {
     @media (min-width: $large-breakpoint) {
       font-size: 2.5rem;
     }
-  }
-
-  // Short accent rule beneath post/page titles
-  &::after {
-    background: $link-color;
-    content: '';
-    display: block;
-    height: 2px;
-    margin-top: 1.1rem;
-    width: 2.5rem;
   }
 }
 

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -39,28 +39,18 @@
   gap: 0.25rem 1.4rem;
 
   a {
-    background-image: linear-gradient($link-color, $link-color);
-    background-position: 0 100%;
-    background-repeat: no-repeat;
-    background-size: 0% 1px;
     color: $body-muted;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
-    padding-bottom: 3px;
     text-transform: uppercase;
-    transition:
-      color 0.25s ease,
-      background-size 0.3s ease;
 
     &:hover,
     &:focus {
-      background-size: 100% 1px;
       color: $link-color;
       text-decoration: none;
     }
 
     &.active {
-      background-size: 100% 1px;
       color: $link-color;
     }
   }

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -1,66 +1,77 @@
-// Masthead
+// Masthead / nameplate
 //
-// Slim editorial header: site title at left, nav at right, thin rule below.
-// Flex wrapping doubles as the mobile treatment -- no JS, no hamburger.
-
-.masthead-wrap {
-  border-bottom: 1px solid $border-color;
-}
+// A broadsheet nameplate: large Caslon wordmark and a dateline, set off by a
+// heavy rule, with a ruled section bar beneath. No JS, no hamburger -- the
+// section bar simply wraps on small screens.
 
 .masthead {
-  align-items: baseline;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1.5rem;
-  justify-content: space-between;
   margin: 0 auto;
   max-width: $masthead-width;
-  padding: 1.25rem 1.5rem;
+  padding: 1.75rem 1.5rem 0;
 }
 
-.masthead-title {
+.nameplate {
+  border-bottom: 3px solid $rule-strong;
+  padding-bottom: 0.9rem;
+  text-align: center;
+}
+
+.nameplate-title {
   color: $heading-color;
-  font-family: $display-font-family;
-  font-size: 1.4rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  white-space: nowrap;
+  display: inline-block;
+  font-family: $nameplate-font-family;
+  font-size: 2.6rem;
+  letter-spacing: 0.01em;
+  line-height: 1;
+
+  @media (min-width: $large-breakpoint) {
+    font-size: 3.25rem;
+  }
 
   &:hover,
   &:focus {
-    color: $link-color;
+    color: $heading-color;
     text-decoration: none;
   }
 }
 
-.masthead-nav {
+.nameplate-dateline {
+  color: $body-muted;
+  font-family: $sans-font-family;
+  font-size: 0.66rem;
+  letter-spacing: 0.13em;
+  margin: 0.6rem 0 0;
+  text-transform: uppercase;
+
+  .dateline-sep {
+    margin: 0 0.5rem;
+    opacity: 0.6;
+  }
+}
+
+.section-bar {
+  border-bottom: 1px solid $rule-strong;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem 1.4rem;
+  gap: 0.4rem 1.6rem;
+  justify-content: center;
+  padding: 0.7rem 0;
 
   a {
-    background-image: linear-gradient($link-color, $link-color);
-    background-position: 0 100%;
-    background-repeat: no-repeat;
-    background-size: 0% 1px;
-    color: $body-muted;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    padding-bottom: 3px;
+    color: $ink-soft;
+    font-family: $sans-font-family;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    transition:
-      color 0.25s ease,
-      background-size 0.3s ease;
 
     &:hover,
     &:focus {
-      background-size: 100% 1px;
       color: $link-color;
       text-decoration: none;
     }
 
     &.active {
-      background-size: 100% 1px;
       color: $link-color;
     }
   }

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -1,25 +1,58 @@
 // Masthead
 //
-// Super small header above the content for site name and short description.
+// Slim editorial header: site title at left, nav at right, thin rule below.
+// Flex wrapping doubles as the mobile treatment -- no JS, no hamburger.
+
+.masthead-wrap {
+  border-bottom: 1px solid $border-color;
+}
 
 .masthead {
-  margin-bottom: 3rem;
-  padding-bottom: 1rem;
-  padding-top: 1rem;
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: $masthead-width;
+  padding: 1.25rem 1.5rem;
 }
 
 .masthead-title {
-  color: $gray-5;
-  margin-bottom: 0;
-  margin-top: 0;
+  color: $heading-color;
+  font-family: $display-font-family;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+
+  &:hover,
+  &:focus {
+    color: $link-color;
+    text-decoration: none;
+  }
+}
+
+.masthead-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.4rem;
 
   a {
-    color: inherit;
-  }
+    color: $body-muted;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 
-  small {
-    font-size: 75%;
-    font-weight: 400;
-    opacity: 0.5;
+    &:hover,
+    &:focus {
+      color: $link-color;
+      text-decoration: underline;
+      text-underline-offset: 4px;
+    }
+
+    &.active {
+      color: $link-color;
+    }
   }
 }

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -21,10 +21,9 @@
 .masthead-title {
   color: $heading-color;
   font-family: $display-font-family;
-  font-size: 1.6rem;
-  font-style: italic; // a small wink -- the name is an imperative, so lean in
+  font-size: 1.4rem;
   font-weight: 600;
-  letter-spacing: -0.015em;
+  letter-spacing: -0.01em;
   white-space: nowrap;
 
   &:hover,

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -1,77 +1,66 @@
-// Masthead / nameplate
+// Masthead
 //
-// A broadsheet nameplate: large Caslon wordmark and a dateline, set off by a
-// heavy rule, with a ruled section bar beneath. No JS, no hamburger -- the
-// section bar simply wraps on small screens.
+// Slim editorial header: site title at left, nav at right, thin rule below.
+// Flex wrapping doubles as the mobile treatment -- no JS, no hamburger.
+
+.masthead-wrap {
+  border-bottom: 1px solid $border-color;
+}
 
 .masthead {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  justify-content: space-between;
   margin: 0 auto;
   max-width: $masthead-width;
-  padding: 1.75rem 1.5rem 0;
+  padding: 1.25rem 1.5rem;
 }
 
-.nameplate {
-  border-bottom: 3px solid $rule-strong;
-  padding-bottom: 0.9rem;
-  text-align: center;
-}
-
-.nameplate-title {
+.masthead-title {
   color: $heading-color;
-  display: inline-block;
-  font-family: $nameplate-font-family;
-  font-size: 2.6rem;
-  letter-spacing: 0.01em;
-  line-height: 1;
-
-  @media (min-width: $large-breakpoint) {
-    font-size: 3.25rem;
-  }
+  font-family: $display-font-family;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
 
   &:hover,
   &:focus {
-    color: $heading-color;
+    color: $link-color;
     text-decoration: none;
   }
 }
 
-.nameplate-dateline {
-  color: $body-muted;
-  font-family: $sans-font-family;
-  font-size: 0.66rem;
-  letter-spacing: 0.13em;
-  margin: 0.6rem 0 0;
-  text-transform: uppercase;
-
-  .dateline-sep {
-    margin: 0 0.5rem;
-    opacity: 0.6;
-  }
-}
-
-.section-bar {
-  border-bottom: 1px solid $rule-strong;
+.masthead-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 1.6rem;
-  justify-content: center;
-  padding: 0.7rem 0;
+  gap: 0.25rem 1.4rem;
 
   a {
-    color: $ink-soft;
-    font-family: $sans-font-family;
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
+    background-image: linear-gradient($link-color, $link-color);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    color: $body-muted;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    padding-bottom: 3px;
     text-transform: uppercase;
+    transition:
+      color 0.25s ease,
+      background-size 0.3s ease;
 
     &:hover,
     &:focus {
+      background-size: 100% 1px;
       color: $link-color;
       text-decoration: none;
     }
 
     &.active {
+      background-size: 100% 1px;
       color: $link-color;
     }
   }

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -39,19 +39,28 @@
   gap: 0.25rem 1.4rem;
 
   a {
+    background-image: linear-gradient($link-color, $link-color);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
     color: $body-muted;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
+    padding-bottom: 3px;
     text-transform: uppercase;
+    transition:
+      color 0.25s ease,
+      background-size 0.3s ease;
 
     &:hover,
     &:focus {
+      background-size: 100% 1px;
       color: $link-color;
-      text-decoration: underline;
-      text-underline-offset: 4px;
+      text-decoration: none;
     }
 
     &.active {
+      background-size: 100% 1px;
       color: $link-color;
     }
   }

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -21,9 +21,10 @@
 .masthead-title {
   color: $heading-color;
   font-family: $display-font-family;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
+  font-style: italic; // a small wink -- the name is an imperative, so lean in
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
   white-space: nowrap;
 
   &:hover,

--- a/_sass/hydeout/_pagination.scss
+++ b/_sass/hydeout/_pagination.scss
@@ -1,72 +1,43 @@
 /*
   Pagination
 
-  Super lightweight (HTML-wise) blog pagination. Should only be visible
-  when there is navigation available -- single buttons at top or bottom
-  of each page.
+  Quiet text buttons centered above/below the post list. Should only be
+  visible when there is navigation available.
 */
 
 .pagination {
-  color: $gray-3;
   margin-bottom: $section-spacing;
   text-align: center;
 
   > a {
-    background: $body-bg;
-    border: solid $border-color;
-    border-radius: $border-radius;
-    border-width: 1px;
-    box-shadow: $default-box-shadow;
+    border: 1px solid $border-color;
+    border-radius: 999px;
+    color: $body-muted;
     display: inline-block;
-    max-width: $sidebar-width;
-    padding: $padding-v $padding-h;
-    width: 60%;
-  }
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    padding: 0.5em 1.8em;
+    text-transform: uppercase;
+    transition: color 0.2s ease, border-color 0.2s ease;
 
-  > a:hover {
-    background-color: $border-color;
+    &:hover,
+    &:focus {
+      border-color: $link-color;
+      color: $link-color;
+      text-decoration: none;
+    }
+
+    &.newer::before {
+      content: '\2190\00a0'; // left arrow
+    }
+
+    &.older::after {
+      content: '\00a0\2192'; // right arrow
+    }
   }
 }
 
 // Bottom -> margin-top;
 * + .pagination {
   margin-top: $section-spacing;
-}
-
-// Push above header if newer on mobile
-.content .pagination:first-child {
-  margin-top: -$section-spacing * 2;
-}
-
-// Make room for larger header by extending margin below title
-.index #sidebar {
-  padding-bottom: calc(#{$section-spacing} + #{$padding-v});
-}
-
-// But not on page1
-.home.index #sidebar {
-  padding-bottom: $section-spacing;
-}
-
-// Undo for larger screens
-@media (min-width: $large-breakpoint) {
-  .pagination > a {
-    box-shadow: none;
-
-    &:hover { box-shadow: $default-box-shadow; }
-  }
-
-  .content .pagination:first-child {
-    margin-top: 0;
-
-    + * {
-      border-top: 1px solid $border-color;
-      margin-top: $section-spacing;
-      padding-top: $section-spacing;
-    }
-  }
-
-  .index #sidebar {
-    padding-bottom: $section-spacing;
-  }
 }

--- a/_sass/hydeout/_posts.scss
+++ b/_sass/hydeout/_posts.scss
@@ -47,7 +47,7 @@ h2.page-title {
   }
 
   li small {
-    color: #999;
+    color: $body-muted;
     font-size: 75%;
     white-space: nowrap;
   }
@@ -62,7 +62,6 @@ h2.page-title {
   }
 }
 
-article + *,
 .post-body ~ section {
   border-top: 1px solid $border-color;
   margin-top: 1.5rem;

--- a/_sass/hydeout/_type.scss
+++ b/_sass/hydeout/_type.scss
@@ -82,13 +82,10 @@ abbr {
 }
 
 blockquote {
-  background: rgba($terracotta, 0.04);
-  border-left: 3px solid $link-color;
-  border-radius: 0 $border-radius $border-radius 0;
-  color: #5a4f44;
-  font-style: italic;
-  margin: 1.25rem 0;
-  padding: 0.75rem 1.25rem;
+  border-left: 3px solid $gray-3;
+  color: $body-muted;
+  margin: 1.5rem 0;
+  padding: 0.25rem 0 0.25rem 1.25rem;
 
   p:last-child {
     margin-bottom: 0;

--- a/_sass/hydeout/_type.scss
+++ b/_sass/hydeout/_type.scss
@@ -11,9 +11,9 @@ h6,
 .site-title {
   color: $heading-color;
   font-family: $display-font-family;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
   margin-bottom: $heading-spacing;
   text-rendering: optimizeLegibility;
 }
@@ -82,13 +82,13 @@ abbr {
 }
 
 blockquote {
-  background: rgba($terracotta, 0.04);
-  border-left: 3px solid $link-color;
-  border-radius: 0 $border-radius $border-radius 0;
-  color: #5a4f44;
-  font-style: italic;
-  margin: 1.25rem 0;
-  padding: 0.75rem 1.25rem;
+  border-left: 3px solid $rule-strong;
+  color: $ink-soft;
+  font-family: $display-font-family;
+  font-size: 1.2rem;
+  line-height: 1.5;
+  margin: 1.5rem 0;
+  padding: 0.25rem 0 0.25rem 1.5rem;
 
   p:last-child {
     margin-bottom: 0;

--- a/_sass/hydeout/_type.scss
+++ b/_sass/hydeout/_type.scss
@@ -10,7 +10,9 @@ h5,
 h6,
 .site-title {
   color: $heading-color;
+  font-family: $display-font-family;
   font-weight: 600;
+  letter-spacing: -0.01em;
   line-height: 1.25;
   margin-bottom: $heading-spacing;
   text-rendering: optimizeLegibility;
@@ -22,11 +24,11 @@ h1 {
 
 h2 {
   font-size: 1.5rem;
-  margin-top: 1rem;
+  margin-top: 2rem;
 }
 
 h3 {
-  font-size: 1.25rem;
+  font-size: 1.2rem;
   margin-top: 1.5rem;
 }
 
@@ -43,7 +45,7 @@ p {
 }
 
 strong {
-  color: #303030;
+  color: $heading-color;
 }
 
 ul,
@@ -63,14 +65,12 @@ dd {
 
 hr {
   border: 0;
-  border-bottom: 1px solid #fff;
-  border-top: 1px solid #eee;
-  margin: 1.5rem 0;
-  position: relative;
+  border-top: 1px solid $border-color;
+  margin: 2rem 0;
 }
 
 abbr {
-  color: #555;
+  color: $body-muted;
   font-size: 85%;
   font-weight: bold;
   text-transform: uppercase;
@@ -82,18 +82,16 @@ abbr {
 }
 
 blockquote {
-  border-left: 0.25rem solid $border-color;
-  color: #7a7a7a;
-  margin: 0.8rem 0;
-  padding: 0.5rem 1rem;
+  background: rgba($terracotta, 0.04);
+  border-left: 3px solid $link-color;
+  border-radius: 0 $border-radius $border-radius 0;
+  color: #5a4f44;
+  font-style: italic;
+  margin: 1.25rem 0;
+  padding: 0.75rem 1.25rem;
 
   p:last-child {
     margin-bottom: 0;
-  }
-
-  @media (min-width: 30em) {
-    padding-left: 1.25rem;
-    padding-right: 5rem;
   }
 }
 
@@ -112,8 +110,11 @@ a[href^='#fnref:'] {
 
 // List of footnotes
 .footnotes {
+  border-top: 1px solid $border-color;
+  color: $body-muted;
   font-size: 85%;
-  margin-top: 2rem;
+  margin-top: 2.5rem;
+  padding-top: 1rem;
 }
 
 // Custom type

--- a/_sass/hydeout/_type.scss
+++ b/_sass/hydeout/_type.scss
@@ -11,9 +11,9 @@ h6,
 .site-title {
   color: $heading-color;
   font-family: $display-font-family;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
   margin-bottom: $heading-spacing;
   text-rendering: optimizeLegibility;
 }
@@ -82,13 +82,13 @@ abbr {
 }
 
 blockquote {
-  border-left: 3px solid $rule-strong;
-  color: $ink-soft;
-  font-family: $display-font-family;
-  font-size: 1.2rem;
-  line-height: 1.5;
-  margin: 1.5rem 0;
-  padding: 0.25rem 0 0.25rem 1.5rem;
+  background: rgba($terracotta, 0.04);
+  border-left: 3px solid $link-color;
+  border-radius: 0 $border-radius $border-radius 0;
+  color: #5a4f44;
+  font-style: italic;
+  margin: 1.25rem 0;
+  padding: 0.75rem 1.25rem;
 
   p:last-child {
     margin-bottom: 0;

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -1,58 +1,49 @@
-// Modern neutral palette
-$gray-1: #fafafa !default;
-$gray-2: #f4f4f5 !default;
-$gray-3: #e4e4e7 !default;
-$gray-4: #71717a !default;
-$gray-5: #3f3f46 !default;
-$gray-6: #27272a !default;
+// Warm editorial palette
+$paper: #faf6f0 !default; // cream paper background
+$ink: #1a1612 !default; // heading ink
+$ink-soft: #2b241d !default; // body ink
+$ink-muted: #6e6258 !default; // meta / muted text
+$terracotta: #c2410c !default; // accent
+$terracotta-dark: #9a3412 !default; // inline code accent
+$hairline: #e7decf !default; // warm hairline borders
+$wash: #f4eee3 !default; // code blocks / tinted panels
+$wash-strong: #f1eae0 !default; // table headers
 
-// Modern accent colors
-$red: #ef4444 !default;
-$orange: #f97316 !default;
-$yellow: #eab308 !default;
-$green: #22c55e !default;
-$cyan: #06b6d4 !default;
-$blue: #3b82f6 !default;
-$purple: #8b5cf6 !default;
-$pink: #ec4899 !default;
-$indigo: #6366f1 !default;
-$brown: #8f5536 !default;
+// Warm neutral scale (kept for partials that expect grays)
+$gray-1: #f3ede3 !default;
+$gray-2: $hairline !default;
+$gray-3: #d8ccb9 !default;
+$gray-4: $ink-muted !default;
+$gray-5: $ink-soft !default;
+$gray-6: $ink !default;
 
-$root-font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif !default;
-$root-font-size: 0.95rem !default;
-$root-line-height: 1.5 !default;
+$display-font-family: 'Fraunces', Georgia, 'Times New Roman', serif !default;
+$root-font-family: 'Source Serif 4', Georgia, 'Times New Roman', serif !default;
+$root-font-size: 1.0625rem !default;
+$root-line-height: 1.7 !default;
 
-$body-color: $gray-5 !default;
-$body-muted: $gray-4 !default;
-$body-bg: #fff !default;
-$link-color: $indigo !default;
-$heading-color: $gray-6 !default;
+$body-color: $ink-soft !default;
+$body-muted: $ink-muted !default;
+$body-bg: $paper !default;
+$link-color: $terracotta !default;
+$heading-color: $ink !default;
 
-$border-color: $gray-2 !default;
-$border-radius: 300px !default;
+$border-color: $hairline !default;
+$border-radius: 6px !default;
 $padding-v: 1em !default;
 $padding-h: 1.5em !default;
 $heading-spacing: 0.5rem !default;
 $section-spacing: 2rem !default;
-$sidebar-width: 18rem !default;
+
+$measure: 42rem !default; // comfortable reading measure
+$masthead-width: 52rem !default;
 
 $large-breakpoint: 49rem !default;
-$large-font-size: 1.25rem !default;
+$large-font-size: 1.125rem !default;
 
 $box-shadow-size: 1px !default;
 $box-shadow-opacity: 0.16 !default;
 $default-box-shadow: $box-shadow-size $box-shadow-size $box-shadow-size rgba(0, 0, 0, $box-shadow-opacity);
 
-$code-font-family: Menlo, Monaco, 'Courier New', monospace !default;
-$code-color: #bf616a !default;
-
-// Hyde theming - Modern dark theme
-$sidebar-bg-color: #1e293b !default;
-$sidebar-fg-color: #f8fafc !default;
-$sidebar-sticky: true !default;
-$layout-reverse: false !default;
-
-$sidebar-title-color: $sidebar-fg-color !default;
-$sidebar-link-color: rgba($sidebar-fg-color, 0.9) !default;
-$sidebar-text-color: rgba($sidebar-fg-color, 0.7) !default;
-$sidebar-icon-color: rgba($sidebar-fg-color, 0.8) !default;
+$code-font-family: ui-monospace, 'SF Mono', Menlo, Monaco, 'Courier New', monospace !default;
+$code-color: $terracotta-dark !default;

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -1,23 +1,28 @@
-// Warm editorial palette
-$paper: #faf6f0 !default; // cream paper background
-$ink: #1a1612 !default; // heading ink
-$ink-soft: #2b241d !default; // body ink
-$ink-muted: #6e6258 !default; // meta / muted text
-$terracotta: #b23c0a !default; // accent (deepened slightly for AA headroom)
-$terracotta-dark: #9a3412 !default; // inline code accent
-$hairline: #e7decf !default; // warm hairline borders
-$wash: #f4eee3 !default; // code blocks / tinted panels
-$wash-strong: #f1eae0 !default; // table headers
+// Warm newsprint palette
+$paper: #f5f2ec !default; // warm newsprint background (cooler than cream)
+$ink: #1a1714 !default; // headline ink, near-black
+$ink-soft: #29251f !default; // body ink
+$ink-muted: #6a6157 !default; // meta / byline text
+$terracotta: #8c1d18 !default; // masthead red accent (deep oxblood)
+$terracotta-dark: #6f1714 !default; // inline code / pressed accent
+$hairline: #d6cfc1 !default; // story-divider rules
+$rule-strong: #1a1714 !default; // heavy nameplate / section-bar rule
+$wash: #ece8df !default; // code blocks / tinted panels
+$wash-strong: #e7e2d7 !default; // table headers
 
 // Warm neutral scale (kept for partials that expect grays)
-$gray-1: #f3ede3 !default;
+$gray-1: #efebe2 !default;
 $gray-2: $hairline !default;
-$gray-3: #d8ccb9 !default;
+$gray-3: #c7bfae !default;
 $gray-4: $ink-muted !default;
 $gray-5: $ink-soft !default;
 $gray-6: $ink !default;
 
-$display-font-family: 'Fraunces', Georgia, 'Times New Roman', serif !default;
+// Type: Caslon for the nameplate + headlines, a Franklin sans for labels and
+// decks, a readable serif for body copy. Sans/serif contrast reads "newspaper".
+$nameplate-font-family: 'Libre Caslon Display', Georgia, 'Times New Roman', serif !default;
+$display-font-family: 'Libre Caslon Text', Georgia, 'Times New Roman', serif !default;
+$sans-font-family: 'Libre Franklin', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !default;
 $root-font-family: 'Source Serif 4', Georgia, 'Times New Roman', serif !default;
 $root-font-size: 1.0625rem !default;
 $root-line-height: 1.7 !default;
@@ -29,14 +34,14 @@ $link-color: $terracotta !default;
 $heading-color: $ink !default;
 
 $border-color: $hairline !default;
-$border-radius: 6px !default;
+$border-radius: 0 !default; // square corners -- newspapers don't round things
 $padding-v: 1em !default;
 $padding-h: 1.5em !default;
 $heading-spacing: 0.5rem !default;
 $section-spacing: 2rem !default;
 
 $measure: 42rem !default; // comfortable reading measure
-$masthead-width: 52rem !default;
+$masthead-width: 54rem !default;
 
 $large-breakpoint: 49rem !default;
 $large-font-size: 1.125rem !default;

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -1,28 +1,23 @@
-// Warm newsprint palette
-$paper: #f5f2ec !default; // warm newsprint background (cooler than cream)
-$ink: #1a1714 !default; // headline ink, near-black
-$ink-soft: #29251f !default; // body ink
-$ink-muted: #6a6157 !default; // meta / byline text
-$terracotta: #8c1d18 !default; // masthead red accent (deep oxblood)
-$terracotta-dark: #6f1714 !default; // inline code / pressed accent
-$hairline: #d6cfc1 !default; // story-divider rules
-$rule-strong: #1a1714 !default; // heavy nameplate / section-bar rule
-$wash: #ece8df !default; // code blocks / tinted panels
-$wash-strong: #e7e2d7 !default; // table headers
+// Warm editorial palette
+$paper: #faf6f0 !default; // cream paper background
+$ink: #1a1612 !default; // heading ink
+$ink-soft: #2b241d !default; // body ink
+$ink-muted: #6e6258 !default; // meta / muted text
+$terracotta: #b23c0a !default; // accent (deepened slightly for AA headroom)
+$terracotta-dark: #9a3412 !default; // inline code accent
+$hairline: #e7decf !default; // warm hairline borders
+$wash: #f4eee3 !default; // code blocks / tinted panels
+$wash-strong: #f1eae0 !default; // table headers
 
 // Warm neutral scale (kept for partials that expect grays)
-$gray-1: #efebe2 !default;
+$gray-1: #f3ede3 !default;
 $gray-2: $hairline !default;
-$gray-3: #c7bfae !default;
+$gray-3: #d8ccb9 !default;
 $gray-4: $ink-muted !default;
 $gray-5: $ink-soft !default;
 $gray-6: $ink !default;
 
-// Type: Caslon for the nameplate + headlines, a Franklin sans for labels and
-// decks, a readable serif for body copy. Sans/serif contrast reads "newspaper".
-$nameplate-font-family: 'Libre Caslon Display', Georgia, 'Times New Roman', serif !default;
-$display-font-family: 'Libre Caslon Text', Georgia, 'Times New Roman', serif !default;
-$sans-font-family: 'Libre Franklin', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !default;
+$display-font-family: 'Fraunces', Georgia, 'Times New Roman', serif !default;
 $root-font-family: 'Source Serif 4', Georgia, 'Times New Roman', serif !default;
 $root-font-size: 1.0625rem !default;
 $root-line-height: 1.7 !default;
@@ -34,14 +29,14 @@ $link-color: $terracotta !default;
 $heading-color: $ink !default;
 
 $border-color: $hairline !default;
-$border-radius: 0 !default; // square corners -- newspapers don't round things
+$border-radius: 6px !default;
 $padding-v: 1em !default;
 $padding-h: 1.5em !default;
 $heading-spacing: 0.5rem !default;
 $section-spacing: 2rem !default;
 
 $measure: 42rem !default; // comfortable reading measure
-$masthead-width: 54rem !default;
+$masthead-width: 52rem !default;
 
 $large-breakpoint: 49rem !default;
 $large-font-size: 1.125rem !default;

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -3,7 +3,7 @@ $paper: #faf6f0 !default; // cream paper background
 $ink: #1a1612 !default; // heading ink
 $ink-soft: #2b241d !default; // body ink
 $ink-muted: #6e6258 !default; // meta / muted text
-$terracotta: #c2410c !default; // accent
+$terracotta: #b23c0a !default; // accent (deepened slightly for AA headroom)
 $terracotta-dark: #9a3412 !default; // inline code accent
 $hairline: #e7decf !default; // warm hairline borders
 $wash: #f4eee3 !default; // code blocks / tinted panels

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -86,15 +86,13 @@
 .post-body {
   line-height: 1.75;
 
-  // Figures: a lightly framed image with a quiet, centered caption beneath.
-  // Captions are authored as an italic line right under the image, so they
-  // render as `<p><img> <em>caption</em></p>`.
   img {
-    border: 1px solid $hairline;
     border-radius: $border-radius;
-    margin: 1.5rem auto 0;
+    margin: 1.5rem 0 0;
   }
 
+  // Captions are authored as an italic line right under the image, so they
+  // render as `<p><img> <em>caption</em></p>`. Render that as a real caption.
   p img:only-child {
     margin-bottom: 1.5rem;
   }
@@ -107,27 +105,6 @@
     margin: 0.6rem 0 1.5rem;
     text-align: center;
   }
-}
-
-// Footer voice -- a personal sign-off and a small colophon
-.footer-note {
-  color: $body-color;
-  font-family: $display-font-family;
-  font-size: 1rem;
-  font-style: italic;
-  line-height: 1.5;
-  margin: 0 auto 1.25rem;
-  max-width: 30rem;
-
-  a {
-    color: $link-color;
-  }
-}
-
-.footer-colophon {
-  font-size: 0.72rem;
-  letter-spacing: 0.03em;
-  opacity: 0.85;
 }
 
 // Tags below posts: quiet #tag links

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -29,6 +29,63 @@
   }
 }
 
+// Quiet section labels dividing the home page into a table of contents
+.home-section-title {
+  color: $body-muted;
+  font-family: $root-font-family;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  margin: 0 0 1.25rem;
+  text-transform: uppercase;
+}
+
+// Things I build & run
+.home-projects {
+  border-bottom: 1px solid $border-color;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2.5rem;
+
+  .projects-list {
+    display: grid;
+    gap: 1.25rem 2.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    @media (min-width: $large-breakpoint) {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  li a {
+    color: $heading-color;
+    display: inline-block;
+    font-family: $display-font-family;
+    font-size: 1.15rem;
+    font-weight: 600;
+
+    &:hover,
+    &:focus {
+      color: $link-color;
+      text-decoration: none;
+    }
+  }
+
+  .project-blurb {
+    color: $body-color;
+    display: block;
+    font-size: 0.92rem;
+    line-height: 1.5;
+  }
+
+  .project-note {
+    color: $body-muted;
+    display: block;
+    font-size: 0.8rem;
+  }
+}
+
 // Meta line (home entries + post pages)
 .entry-meta,
 .post-meta {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,129 +5,48 @@
 
 @import "hydeout";
 
-// Warm Editorial component layer
-// Base palette, type, and layout live in _sass/hydeout/*; this file only
-// styles the site-specific components (home list, post page, tags, etc.).
+// Newspaper component layer
+// Base palette, type, and the nameplate live in _sass/hydeout/*; this file
+// styles the site-specific components: the section kicker, the home story
+// list, post bylines, and the tag/category/related lists.
 
-// Home intro
-.home-intro {
-  margin-bottom: 1.75rem;
-
-  .home-kicker {
-    align-items: center;
-    color: $link-color;
-    display: flex;
-    font-family: $root-font-family;
-    font-size: 0.72rem;
-    font-weight: 600;
-    gap: 0.6rem;
-    letter-spacing: 0.18em;
-    margin: 0 0 0.85rem;
-    text-transform: uppercase;
-
-    &::before {
-      background: $link-color;
-      content: '';
-      display: inline-block;
-      height: 1px;
-      width: 1.75rem;
-    }
-  }
-
-  h1 {
-    font-size: 2.5rem;
-    line-height: 1.1;
-    margin-bottom: 0.75rem;
-
-    @media (min-width: $large-breakpoint) {
-      font-size: 2.75rem;
-    }
-  }
-
-  .home-tagline {
-    color: $body-muted;
-    font-style: italic;
-    margin: 0;
-  }
-}
-
-// Flourish divider between the intro and the post list
-.ornament {
-  color: rgba($terracotta, 0.55);
-  font-size: 1.4rem;
-  line-height: 1;
-  margin: 0 0 2.75rem;
-  text-align: center;
-}
-
-// Small-caps style meta line (home entries + post pages)
-.entry-meta,
-.post-meta {
-  color: $body-muted;
-  font-size: 0.72rem;
-  font-style: normal;
-  letter-spacing: 0.1em;
+// Section kicker -- the red sans label above a headline (home + post head)
+.story-kicker {
+  color: $link-color;
+  font-family: $sans-font-family;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  margin: 0 0 0.5rem;
   text-transform: uppercase;
-
-  .entry-category {
-    color: $link-color;
-  }
-
-  a {
-    color: $link-color;
-  }
 }
 
-// "Latest" pill on the lead entry
-.entry-flag {
-  background: $link-color;
-  border-radius: 999px;
-  color: $paper;
-  font-size: 0.62rem;
-  letter-spacing: 0.12em;
-  margin-right: 0.6rem;
-  padding: 0.15em 0.55em;
-  vertical-align: 0.08em;
-}
+// Home story list: hairline-divided stories, no cards, no ornament
+.story-list {
+  .story {
+    border-top: 1px solid $hairline;
+    padding: 1.75rem 0;
 
-// Editorial post list on the home page
-.home-posts .home-post {
-  border-bottom: 1px solid $border-color;
-  display: flex;
-  gap: 1.25rem;
-  margin-bottom: 2rem;
-  padding-bottom: 2rem;
+    &:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
 
-  &:last-child {
-    border-bottom: 0;
-    margin-bottom: 0;
-    padding-bottom: 0;
-  }
-
-  // Hanging magazine-style index numeral
-  .entry-index {
-    color: rgba($terracotta, 0.5);
-    flex-shrink: 0;
-    font-family: $display-font-family;
-    font-feature-settings: 'tnum' 1;
-    font-size: 1.05rem;
-    font-weight: 600;
-    line-height: 1.9;
-    width: 1.6rem;
-
-    @media (min-width: $large-breakpoint) {
-      font-size: 1.15rem;
+    &:last-child {
+      padding-bottom: 0;
     }
   }
 
-  .entry-body {
-    min-width: 0;
-  }
+  .story-headline {
+    font-family: $display-font-family;
+    font-size: 1.55rem;
+    font-weight: 700;
+    line-height: 1.16;
+    margin: 0 0 0.5rem;
 
-  .entry-title {
-    font-size: 1.6rem;
-    line-height: 1.2;
-    margin: 0.4rem 0 0.5rem;
+    @media (min-width: $large-breakpoint) {
+      font-size: 1.75rem;
+    }
 
     a {
       color: $heading-color;
@@ -140,86 +59,100 @@
     }
   }
 
-  .entry-excerpt {
-    color: #5a4f44;
-    font-size: 0.95rem;
-    line-height: 1.65;
-    margin: 0;
+  .story-deck {
+    color: $ink-soft;
+    font-family: $sans-font-family;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    margin: 0 0 0.6rem;
   }
 
-  // Lead story: larger billing for the newest post
-  &.is-lead {
-    .entry-index {
-      line-height: 2.4;
-    }
+  .story-byline {
+    color: $body-muted;
+    font-family: $sans-font-family;
+    font-size: 0.7rem;
+    letter-spacing: 0.07em;
+    margin: 0;
+    text-transform: uppercase;
 
-    .entry-title {
-      font-size: 2.1rem;
-      line-height: 1.12;
+    .byline-sep {
+      margin: 0 0.35rem;
+      opacity: 0.6;
+    }
+  }
+
+  // Lead story: a front-page splash with a larger headline + deck
+  .story--lead {
+    .story-headline {
+      font-size: 2rem;
 
       @media (min-width: $large-breakpoint) {
-        font-size: 2.35rem;
+        font-size: 2.7rem;
       }
     }
 
-    .entry-excerpt {
+    .story-deck {
       font-size: 1.05rem;
-      line-height: 1.7;
+      line-height: 1.6;
     }
   }
 }
 
-// Post pages
+// Post byline (date / reading time) below the headline
 .post-meta {
-  margin-bottom: 2rem;
+  color: $body-muted;
+  font-family: $sans-font-family;
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  margin-bottom: 2.25rem;
+  margin-top: 1.25rem;
+  text-transform: uppercase;
+
+  .meta-sep {
+    margin: 0 0.4rem;
+    opacity: 0.6;
+  }
 }
 
+// Post body
 .post-body {
   line-height: 1.75;
 
   img {
-    border-radius: $border-radius;
     margin: 1.5rem 0;
   }
 
-  // Inline links: terracotta underline that wipes in on hover
+  // In-text links: a plain newspaper underline that thickens on hover
   p a,
   li a {
-    background-image: linear-gradient($link-color, $link-color);
-    background-position: 0 1.15em;
-    background-repeat: no-repeat;
-    background-size: 0% 1px;
-    transition: background-size 0.3s ease;
+    color: $link-color;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
 
     &:hover,
     &:focus {
-      background-size: 100% 1px;
-      text-decoration: none;
+      text-decoration-thickness: 2px;
     }
   }
 }
 
-// Drop cap on the opening paragraph; opt out per-post with `dropcap: false`
-.dropcap > p:first-of-type::first-letter {
-  color: $link-color;
-  float: left;
-  font-family: $display-font-family;
-  font-size: 3.4em;
-  font-weight: 600;
-  line-height: 0.85;
-  padding: 0.05em 0.08em 0 0;
-}
-
-// Tags below posts: quiet #tag links
+// Tags below a post: quiet #tag links
 .post-tags {
+  border-top: 1px solid $hairline;
+  margin-top: 2.25rem;
+  padding-top: 1.25rem;
+
   > a,
   > span {
     color: $body-muted;
     display: inline-block;
-    font-size: 0.85rem;
-    margin-bottom: 0.5rem;
+    font-family: $sans-font-family;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.4rem;
     margin-right: 1rem;
-    opacity: 1;
+    text-transform: uppercase;
     white-space: nowrap;
 
     .icon {
@@ -237,14 +170,18 @@
   }
 }
 
-// Related posts + tag page post lists (title with inline date)
+// Related posts + tag-page lists: a sans section label over serif headlines
 .related,
 .posts-for-tag {
+  border-top: 1px solid $hairline;
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+
   h2 {
-    color: $body-muted;
-    font-family: $root-font-family;
-    font-size: 0.8rem;
-    font-weight: 600;
+    color: $ink;
+    font-family: $sans-font-family;
+    font-size: 0.78rem;
+    font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
@@ -253,7 +190,9 @@
     margin-bottom: 1rem;
 
     h3 {
+      font-family: $display-font-family;
       font-size: 1.15rem;
+      font-weight: 700;
       margin: 0;
 
       a {
@@ -271,7 +210,9 @@
       }
 
       small {
-        font-family: $root-font-family;
+        color: $body-muted;
+        font-family: $sans-font-family;
+        font-size: 0.7rem;
         font-weight: 400;
         letter-spacing: 0.06em;
         margin-left: 0.5rem;
@@ -281,7 +222,7 @@
   }
 }
 
-// Category pages: date + title rows
+// Category pages: date + headline rows
 .category .posts-list li {
   align-items: baseline;
   display: flex;
@@ -289,19 +230,20 @@
   margin-bottom: 0.85rem;
 
   small {
+    color: $body-muted;
     flex-shrink: 0;
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
+    font-family: $sans-font-family;
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
     min-width: 6.5rem;
     text-transform: uppercase;
   }
 
   h3 {
-    font-family: $root-font-family;
-    font-size: 1.05rem;
-    font-weight: 500;
-    letter-spacing: 0;
-    line-height: 1.4;
+    font-family: $display-font-family;
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: 1.3;
     margin: 0;
 
     a {
@@ -318,7 +260,6 @@
 
 // About page portrait
 .about-image {
-  border-radius: $border-radius;
   display: block;
   margin: 1.5rem auto;
   max-width: 300px;
@@ -331,113 +272,61 @@
 // ---------------------------------------------------------------------------
 // Phone optimizations
 //
-// Scoped to <= 40rem so the desktop (>= $large-breakpoint) and tablet layouts
-// are left exactly as-is. This block only refines the small-screen reading and
-// navigation experience: a stacked masthead, gentler type scale so long titles
-// don't fragment, tighter index numerals, and no accidental horizontal scroll.
+// Scoped to <= 40rem so the desktop and tablet layouts are left as-is. Only
+// scales the nameplate, story headlines, and gutters for a narrow column.
 // ---------------------------------------------------------------------------
 $phone-breakpoint: 40rem;
 
 @media (max-width: $phone-breakpoint) {
-  // Two-row masthead: title, then a full-width nav with bigger tap targets
   .masthead {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 0.75rem;
-    padding: 1rem 1.15rem 0.9rem;
+    padding: 1.25rem 1.15rem 0;
   }
 
-  .masthead-nav {
-    gap: 0.2rem 1.3rem;
-
-    a {
-      // Taller hit area while keeping the underline tight to the text
-      padding-bottom: 0.4rem;
-      padding-top: 0.2rem;
-    }
+  .nameplate-title {
+    font-size: 2rem;
   }
 
-  // Tighter, more comfortable reading gutters
+  .nameplate-dateline {
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+  }
+
+  .section-bar {
+    gap: 0.3rem 1.1rem;
+    padding: 0.6rem 0;
+  }
+
   .container {
     padding: 1.75rem 1.15rem 2.5rem;
   }
 
-  // Keep long titles, URLs, and inline code from forcing the page sideways
+  // Keep long titles, URLs, and inline code from forcing horizontal scroll
   .post-body,
-  .entry-title,
-  .entry-excerpt,
-  .post-title,
-  .page-title {
+  .story-headline,
+  .story-deck,
+  .post-title {
     overflow-wrap: break-word;
   }
 
-  // Home intro: smaller headline, less air before the list
-  .home-intro {
-    margin-bottom: 1.5rem;
+  .story-list {
+    .story-headline {
+      font-size: 1.35rem;
+    }
 
-    h1 {
-      font-size: 2rem;
+    .story--lead .story-headline {
+      font-size: 1.7rem;
+    }
+
+    .story--lead .story-deck {
+      font-size: 1rem;
     }
   }
 
-  .ornament {
-    margin-bottom: 2.25rem;
+  .container > header h1,
+  .container > header h2 {
+    font-size: 1.7rem;
   }
 
-  // Tighten the hanging index numeral so titles keep their width
-  .home-posts .home-post {
-    gap: 0.85rem;
-
-    .entry-index {
-      font-size: 0.92rem;
-      line-height: 1.7;
-      width: 1.2rem;
-    }
-
-    .entry-title {
-      font-size: 1.4rem;
-    }
-
-    .entry-excerpt {
-      font-size: 0.95rem;
-    }
-
-    // Lead story stays the largest, but sized for a narrow column
-    &.is-lead {
-      .entry-index {
-        line-height: 2;
-      }
-
-      .entry-title {
-        font-size: 1.75rem;
-      }
-
-      .entry-excerpt {
-        font-size: 1rem;
-      }
-    }
-  }
-
-  // Post/page titles render in .container > header
-  .container > header {
-    margin-bottom: 1.25rem;
-
-    h1,
-    h2 {
-      font-size: 1.85rem;
-    }
-
-    &::after {
-      margin-top: 0.9rem;
-    }
-  }
-
-  // A smaller drop cap so it doesn't crowd a narrow measure
-  .dropcap > p:first-of-type::first-letter {
-    font-size: 2.8em;
-  }
-
-  // Roomier footer tap targets
   .site-footer .footer-links a {
     display: inline-block;
     padding: 0.3rem 0;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,7 +11,28 @@
 
 // Home intro
 .home-intro {
-  margin-bottom: 3rem;
+  margin-bottom: 1.75rem;
+
+  .home-kicker {
+    align-items: center;
+    color: $link-color;
+    display: flex;
+    font-family: $root-font-family;
+    font-size: 0.72rem;
+    font-weight: 600;
+    gap: 0.6rem;
+    letter-spacing: 0.18em;
+    margin: 0 0 0.85rem;
+    text-transform: uppercase;
+
+    &::before {
+      background: $link-color;
+      content: '';
+      display: inline-block;
+      height: 1px;
+      width: 1.75rem;
+    }
+  }
 
   h1 {
     font-size: 2.5rem;
@@ -28,6 +49,15 @@
     font-style: italic;
     margin: 0;
   }
+}
+
+// Flourish divider between the intro and the post list
+.ornament {
+  color: rgba($terracotta, 0.55);
+  font-size: 1.4rem;
+  line-height: 1;
+  margin: 0 0 2.75rem;
+  text-align: center;
 }
 
 // Small-caps style meta line (home entries + post pages)
@@ -48,9 +78,23 @@
   }
 }
 
+// "Latest" pill on the lead entry
+.entry-flag {
+  background: $link-color;
+  border-radius: 999px;
+  color: $paper;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  margin-right: 0.6rem;
+  padding: 0.15em 0.55em;
+  vertical-align: 0.08em;
+}
+
 // Editorial post list on the home page
 .home-posts .home-post {
   border-bottom: 1px solid $border-color;
+  display: flex;
+  gap: 1.25rem;
   margin-bottom: 2rem;
   padding-bottom: 2rem;
 
@@ -58,6 +102,26 @@
     border-bottom: 0;
     margin-bottom: 0;
     padding-bottom: 0;
+  }
+
+  // Hanging magazine-style index numeral
+  .entry-index {
+    color: rgba($terracotta, 0.5);
+    flex-shrink: 0;
+    font-family: $display-font-family;
+    font-feature-settings: 'tnum' 1;
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.9;
+    width: 1.6rem;
+
+    @media (min-width: $large-breakpoint) {
+      font-size: 1.15rem;
+    }
+  }
+
+  .entry-body {
+    min-width: 0;
   }
 
   .entry-title {
@@ -82,6 +146,27 @@
     line-height: 1.65;
     margin: 0;
   }
+
+  // Lead story: larger billing for the newest post
+  &.is-lead {
+    .entry-index {
+      line-height: 2.4;
+    }
+
+    .entry-title {
+      font-size: 2.1rem;
+      line-height: 1.12;
+
+      @media (min-width: $large-breakpoint) {
+        font-size: 2.35rem;
+      }
+    }
+
+    .entry-excerpt {
+      font-size: 1.05rem;
+      line-height: 1.7;
+    }
+  }
 }
 
 // Post pages
@@ -95,6 +180,22 @@
   img {
     border-radius: $border-radius;
     margin: 1.5rem 0;
+  }
+
+  // Inline links: terracotta underline that wipes in on hover
+  p a,
+  li a {
+    background-image: linear-gradient($link-color, $link-color);
+    background-position: 0 1.15em;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    transition: background-size 0.3s ease;
+
+    &:hover,
+    &:focus {
+      background-size: 100% 1px;
+      text-decoration: none;
+    }
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -105,6 +105,21 @@
     margin: 0.6rem 0 1.5rem;
     text-align: center;
   }
+
+  // Gentle breakout: on large screens, paragraphs that hold an image widen
+  // past the 39rem content box to ~50rem. Images narrower than the box stay
+  // natural size and center; browsers without :has() keep column width.
+  @media (min-width: 54rem) {
+    p:has(> img) {
+      margin-left: -5.5rem;
+      margin-right: -5.5rem;
+      text-align: center;
+    }
+
+    p:has(> img) img {
+      display: inline-block;
+    }
+  }
 }
 
 // Tags below posts: quiet #tag links

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -86,10 +86,48 @@
 .post-body {
   line-height: 1.75;
 
+  // Figures: a lightly framed image with a quiet, centered caption beneath.
+  // Captions are authored as an italic line right under the image, so they
+  // render as `<p><img> <em>caption</em></p>`.
   img {
+    border: 1px solid $hairline;
     border-radius: $border-radius;
-    margin: 1.5rem 0;
+    margin: 1.5rem auto 0;
   }
+
+  p img:only-child {
+    margin-bottom: 1.5rem;
+  }
+
+  p img + em {
+    color: $body-muted;
+    display: block;
+    font-size: 0.85rem;
+    line-height: 1.45;
+    margin: 0.6rem 0 1.5rem;
+    text-align: center;
+  }
+}
+
+// Footer voice -- a personal sign-off and a small colophon
+.footer-note {
+  color: $body-color;
+  font-family: $display-font-family;
+  font-size: 1rem;
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0 auto 1.25rem;
+  max-width: 30rem;
+
+  a {
+    color: $link-color;
+  }
+}
+
+.footer-colophon {
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  opacity: 0.85;
 }
 
 // Tags below posts: quiet #tag links

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -122,6 +122,50 @@
   }
 }
 
+// Older/newer navigation at the foot of a post
+.post-nav {
+  border-top: 1px solid $border-color;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  justify-content: space-between;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+
+  .post-nav-item {
+    max-width: 46%;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+
+      .post-nav-title {
+        color: $link-color;
+      }
+    }
+  }
+
+  .post-nav-newer {
+    margin-left: auto;
+    text-align: right;
+  }
+
+  .post-nav-label {
+    color: $body-muted;
+    display: block;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .post-nav-title {
+    color: $heading-color;
+    font-family: $display-font-family;
+    font-size: 1.05rem;
+    line-height: 1.3;
+  }
+}
+
 // Tags below posts: quiet #tag links
 .post-tags {
   > a,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,48 +5,129 @@
 
 @import "hydeout";
 
-// Newspaper component layer
-// Base palette, type, and the nameplate live in _sass/hydeout/*; this file
-// styles the site-specific components: the section kicker, the home story
-// list, post bylines, and the tag/category/related lists.
+// Warm Editorial component layer
+// Base palette, type, and layout live in _sass/hydeout/*; this file only
+// styles the site-specific components (home list, post page, tags, etc.).
 
-// Section kicker -- the red sans label above a headline (home + post head)
-.story-kicker {
-  color: $link-color;
-  font-family: $sans-font-family;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.13em;
-  margin: 0 0 0.5rem;
-  text-transform: uppercase;
-}
+// Home intro
+.home-intro {
+  margin-bottom: 1.75rem;
 
-// Home story list: hairline-divided stories, no cards, no ornament
-.story-list {
-  .story {
-    border-top: 1px solid $hairline;
-    padding: 1.75rem 0;
+  .home-kicker {
+    align-items: center;
+    color: $link-color;
+    display: flex;
+    font-family: $root-font-family;
+    font-size: 0.72rem;
+    font-weight: 600;
+    gap: 0.6rem;
+    letter-spacing: 0.18em;
+    margin: 0 0 0.85rem;
+    text-transform: uppercase;
 
-    &:first-child {
-      border-top: 0;
-      padding-top: 0;
-    }
-
-    &:last-child {
-      padding-bottom: 0;
+    &::before {
+      background: $link-color;
+      content: '';
+      display: inline-block;
+      height: 1px;
+      width: 1.75rem;
     }
   }
 
-  .story-headline {
-    font-family: $display-font-family;
-    font-size: 1.55rem;
-    font-weight: 700;
-    line-height: 1.16;
-    margin: 0 0 0.5rem;
+  h1 {
+    font-size: 2.5rem;
+    line-height: 1.1;
+    margin-bottom: 0.75rem;
 
     @media (min-width: $large-breakpoint) {
-      font-size: 1.75rem;
+      font-size: 2.75rem;
     }
+  }
+
+  .home-tagline {
+    color: $body-muted;
+    font-style: italic;
+    margin: 0;
+  }
+}
+
+// Flourish divider between the intro and the post list
+.ornament {
+  color: rgba($terracotta, 0.55);
+  font-size: 1.4rem;
+  line-height: 1;
+  margin: 0 0 2.75rem;
+  text-align: center;
+}
+
+// Small-caps style meta line (home entries + post pages)
+.entry-meta,
+.post-meta {
+  color: $body-muted;
+  font-size: 0.72rem;
+  font-style: normal;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+
+  .entry-category {
+    color: $link-color;
+  }
+
+  a {
+    color: $link-color;
+  }
+}
+
+// "Latest" pill on the lead entry
+.entry-flag {
+  background: $link-color;
+  border-radius: 999px;
+  color: $paper;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  margin-right: 0.6rem;
+  padding: 0.15em 0.55em;
+  vertical-align: 0.08em;
+}
+
+// Editorial post list on the home page
+.home-posts .home-post {
+  border-bottom: 1px solid $border-color;
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+
+  &:last-child {
+    border-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  // Hanging magazine-style index numeral
+  .entry-index {
+    color: rgba($terracotta, 0.5);
+    flex-shrink: 0;
+    font-family: $display-font-family;
+    font-feature-settings: 'tnum' 1;
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.9;
+    width: 1.6rem;
+
+    @media (min-width: $large-breakpoint) {
+      font-size: 1.15rem;
+    }
+  }
+
+  .entry-body {
+    min-width: 0;
+  }
+
+  .entry-title {
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0.4rem 0 0.5rem;
 
     a {
       color: $heading-color;
@@ -59,100 +140,86 @@
     }
   }
 
-  .story-deck {
-    color: $ink-soft;
-    font-family: $sans-font-family;
-    font-size: 0.92rem;
-    line-height: 1.55;
-    margin: 0 0 0.6rem;
-  }
-
-  .story-byline {
-    color: $body-muted;
-    font-family: $sans-font-family;
-    font-size: 0.7rem;
-    letter-spacing: 0.07em;
+  .entry-excerpt {
+    color: #5a4f44;
+    font-size: 0.95rem;
+    line-height: 1.65;
     margin: 0;
-    text-transform: uppercase;
-
-    .byline-sep {
-      margin: 0 0.35rem;
-      opacity: 0.6;
-    }
   }
 
-  // Lead story: a front-page splash with a larger headline + deck
-  .story--lead {
-    .story-headline {
-      font-size: 2rem;
+  // Lead story: larger billing for the newest post
+  &.is-lead {
+    .entry-index {
+      line-height: 2.4;
+    }
+
+    .entry-title {
+      font-size: 2.1rem;
+      line-height: 1.12;
 
       @media (min-width: $large-breakpoint) {
-        font-size: 2.7rem;
+        font-size: 2.35rem;
       }
     }
 
-    .story-deck {
+    .entry-excerpt {
       font-size: 1.05rem;
-      line-height: 1.6;
+      line-height: 1.7;
     }
   }
 }
 
-// Post byline (date / reading time) below the headline
+// Post pages
 .post-meta {
-  color: $body-muted;
-  font-family: $sans-font-family;
-  font-size: 0.72rem;
-  letter-spacing: 0.07em;
-  margin-bottom: 2.25rem;
-  margin-top: 1.25rem;
-  text-transform: uppercase;
-
-  .meta-sep {
-    margin: 0 0.4rem;
-    opacity: 0.6;
-  }
+  margin-bottom: 2rem;
 }
 
-// Post body
 .post-body {
   line-height: 1.75;
 
   img {
+    border-radius: $border-radius;
     margin: 1.5rem 0;
   }
 
-  // In-text links: a plain newspaper underline that thickens on hover
+  // Inline links: terracotta underline that wipes in on hover
   p a,
   li a {
-    color: $link-color;
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
+    background-image: linear-gradient($link-color, $link-color);
+    background-position: 0 1.15em;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    transition: background-size 0.3s ease;
 
     &:hover,
     &:focus {
-      text-decoration-thickness: 2px;
+      background-size: 100% 1px;
+      text-decoration: none;
     }
   }
 }
 
-// Tags below a post: quiet #tag links
-.post-tags {
-  border-top: 1px solid $hairline;
-  margin-top: 2.25rem;
-  padding-top: 1.25rem;
+// Drop cap on the opening paragraph; opt out per-post with `dropcap: false`
+.dropcap > p:first-of-type::first-letter {
+  color: $link-color;
+  float: left;
+  font-family: $display-font-family;
+  font-size: 3.4em;
+  font-weight: 600;
+  line-height: 0.85;
+  padding: 0.05em 0.08em 0 0;
+}
 
+// Tags below posts: quiet #tag links
+.post-tags {
   > a,
   > span {
     color: $body-muted;
     display: inline-block;
-    font-family: $sans-font-family;
-    font-size: 0.72rem;
-    letter-spacing: 0.04em;
-    margin-bottom: 0.4rem;
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
     margin-right: 1rem;
-    text-transform: uppercase;
+    opacity: 1;
     white-space: nowrap;
 
     .icon {
@@ -170,18 +237,14 @@
   }
 }
 
-// Related posts + tag-page lists: a sans section label over serif headlines
+// Related posts + tag page post lists (title with inline date)
 .related,
 .posts-for-tag {
-  border-top: 1px solid $hairline;
-  margin-top: 2.5rem;
-  padding-top: 1.5rem;
-
   h2 {
-    color: $ink;
-    font-family: $sans-font-family;
-    font-size: 0.78rem;
-    font-weight: 700;
+    color: $body-muted;
+    font-family: $root-font-family;
+    font-size: 0.8rem;
+    font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
@@ -190,9 +253,7 @@
     margin-bottom: 1rem;
 
     h3 {
-      font-family: $display-font-family;
       font-size: 1.15rem;
-      font-weight: 700;
       margin: 0;
 
       a {
@@ -210,9 +271,7 @@
       }
 
       small {
-        color: $body-muted;
-        font-family: $sans-font-family;
-        font-size: 0.7rem;
+        font-family: $root-font-family;
         font-weight: 400;
         letter-spacing: 0.06em;
         margin-left: 0.5rem;
@@ -222,7 +281,7 @@
   }
 }
 
-// Category pages: date + headline rows
+// Category pages: date + title rows
 .category .posts-list li {
   align-items: baseline;
   display: flex;
@@ -230,20 +289,19 @@
   margin-bottom: 0.85rem;
 
   small {
-    color: $body-muted;
     flex-shrink: 0;
-    font-family: $sans-font-family;
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
     min-width: 6.5rem;
     text-transform: uppercase;
   }
 
   h3 {
-    font-family: $display-font-family;
-    font-size: 1.1rem;
-    font-weight: 700;
-    line-height: 1.3;
+    font-family: $root-font-family;
+    font-size: 1.05rem;
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.4;
     margin: 0;
 
     a {
@@ -260,6 +318,7 @@
 
 // About page portrait
 .about-image {
+  border-radius: $border-radius;
   display: block;
   margin: 1.5rem auto;
   max-width: 300px;
@@ -272,61 +331,113 @@
 // ---------------------------------------------------------------------------
 // Phone optimizations
 //
-// Scoped to <= 40rem so the desktop and tablet layouts are left as-is. Only
-// scales the nameplate, story headlines, and gutters for a narrow column.
+// Scoped to <= 40rem so the desktop (>= $large-breakpoint) and tablet layouts
+// are left exactly as-is. This block only refines the small-screen reading and
+// navigation experience: a stacked masthead, gentler type scale so long titles
+// don't fragment, tighter index numerals, and no accidental horizontal scroll.
 // ---------------------------------------------------------------------------
 $phone-breakpoint: 40rem;
 
 @media (max-width: $phone-breakpoint) {
+  // Two-row masthead: title, then a full-width nav with bigger tap targets
   .masthead {
-    padding: 1.25rem 1.15rem 0;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem 1.15rem 0.9rem;
   }
 
-  .nameplate-title {
-    font-size: 2rem;
+  .masthead-nav {
+    gap: 0.2rem 1.3rem;
+
+    a {
+      // Taller hit area while keeping the underline tight to the text
+      padding-bottom: 0.4rem;
+      padding-top: 0.2rem;
+    }
   }
 
-  .nameplate-dateline {
-    font-size: 0.6rem;
-    letter-spacing: 0.1em;
-  }
-
-  .section-bar {
-    gap: 0.3rem 1.1rem;
-    padding: 0.6rem 0;
-  }
-
+  // Tighter, more comfortable reading gutters
   .container {
     padding: 1.75rem 1.15rem 2.5rem;
   }
 
-  // Keep long titles, URLs, and inline code from forcing horizontal scroll
+  // Keep long titles, URLs, and inline code from forcing the page sideways
   .post-body,
-  .story-headline,
-  .story-deck,
-  .post-title {
+  .entry-title,
+  .entry-excerpt,
+  .post-title,
+  .page-title {
     overflow-wrap: break-word;
   }
 
-  .story-list {
-    .story-headline {
-      font-size: 1.35rem;
-    }
+  // Home intro: smaller headline, less air before the list
+  .home-intro {
+    margin-bottom: 1.5rem;
 
-    .story--lead .story-headline {
-      font-size: 1.7rem;
-    }
-
-    .story--lead .story-deck {
-      font-size: 1rem;
+    h1 {
+      font-size: 2rem;
     }
   }
 
-  .container > header h1,
-  .container > header h2 {
-    font-size: 1.7rem;
+  .ornament {
+    margin-bottom: 2.25rem;
   }
 
+  // Tighten the hanging index numeral so titles keep their width
+  .home-posts .home-post {
+    gap: 0.85rem;
+
+    .entry-index {
+      font-size: 0.92rem;
+      line-height: 1.7;
+      width: 1.2rem;
+    }
+
+    .entry-title {
+      font-size: 1.4rem;
+    }
+
+    .entry-excerpt {
+      font-size: 0.95rem;
+    }
+
+    // Lead story stays the largest, but sized for a narrow column
+    &.is-lead {
+      .entry-index {
+        line-height: 2;
+      }
+
+      .entry-title {
+        font-size: 1.75rem;
+      }
+
+      .entry-excerpt {
+        font-size: 1rem;
+      }
+    }
+  }
+
+  // Post/page titles render in .container > header
+  .container > header {
+    margin-bottom: 1.25rem;
+
+    h1,
+    h2 {
+      font-size: 1.85rem;
+    }
+
+    &::after {
+      margin-top: 0.9rem;
+    }
+  }
+
+  // A smaller drop cap so it doesn't crowd a narrow measure
+  .dropcap > p:first-of-type::first-letter {
+    font-size: 2.8em;
+  }
+
+  // Roomier footer tap targets
   .site-footer .footer-links a {
     display: inline-block;
     padding: 0.3rem 0;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -3,684 +3,226 @@
 # only main files contain this front matter, not partials.
 ---
 
-// Google Fonts Import - Contemporary Minimalist
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=DM+Serif+Display:ital@0;1&display=swap');
-
-// Modern color scheme override  
-$sidebar-bg-color: #0891b2;
-
 @import "hydeout";
 
-// Typography System - Contemporary Minimalist
-body {
-    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    font-size: 1.125rem;
-    line-height: 1.6;
-    letter-spacing: -0.01em;
-    color: #374151;
-}
+// Warm Editorial component layer
+// Base palette, type, and layout live in _sass/hydeout/*; this file only
+// styles the site-specific components (home list, post page, tags, etc.).
 
-// Headings using DM Serif Display
-h1, h2, h3, h4, h5, h6,
-.post-title, .page-title {
-    font-family: 'DM Serif Display', 'Times New Roman', serif;
-    font-weight: 400;
-    letter-spacing: -0.02em;
-    color: #1f2937;
-    line-height: 1.2;
-}
+// Home intro
+.home-intro {
+  margin-bottom: 3rem;
 
-#sidebar {
-    .site-title {
-        font-family: 'DM Serif Display', serif;
-        font-size: 2.5rem !important;
-        font-weight: 400;
-        letter-spacing: -0.02em;
+  h1 {
+    font-size: 2.5rem;
+    line-height: 1.1;
+    margin-bottom: 0.75rem;
+
+    @media (min-width: $large-breakpoint) {
+      font-size: 2.75rem;
     }
+  }
+
+  .home-tagline {
+    color: $body-muted;
+    font-style: italic;
+    margin: 0;
+  }
 }
 
-@media only screen and (max-width: 600px) {
-    #sidebar .site-title {
-        font-size: 1.5rem !important; /* smaller font for phones */
-    }
-}
-
-.alert {
-    position: relative;
-    padding: .75rem 1.25rem;
-    margin-bottom: 1rem;
-    border: 1px solid transparent;
-    border-radius: .25rem;
-}
-
-.alert-info {
-    color: #305d5f;
-    background-color: #dcebeb;
-    border-color: #cee5e5;
-}
-
-// Modern enhancements
-.container {
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-}
-
-// Improved link styling
-a {
-    transition: all 0.3s ease;
-    
-    &:hover {
-        transform: translateY(-1px);
-        text-decoration: none;
-        color: #8b5cf6;
-    }
-}
-
-// Enhanced sidebar links with contemporary typography
-#sidebar {
-    font-family: 'DM Sans', sans-serif;
-    
-    p.lead {
-        font-family: 'DM Sans', sans-serif;
-        font-size: 1rem;
-        line-height: 1.5;
-        font-style: italic;
-        letter-spacing: 0.01em;
-        color: rgba(248, 250, 252, 0.8) !important;
-    }
-    
-    // Copyright text styling
-    p:last-child {
-        color: rgba(248, 250, 252, 0.7) !important;
-        font-size: 0.875rem;
-        font-weight: 400;
-        letter-spacing: 0.01em;
-        
-        a {
-            color: rgba(248, 250, 252, 0.8) !important;
-            
-            &:hover {
-                color: rgba(248, 250, 252, 1) !important;
-            }
-        }
-    }
-    
-    a {
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        font-weight: 500;
-        letter-spacing: 0.01em;
-        
-        &:hover {
-            transform: translateX(4px);
-            opacity: 0.9;
-        }
-    }
-    
-    nav a {
-        font-family: 'DM Sans', sans-serif;
-        font-weight: 500;
-        font-size: 0.95rem;
-        letter-spacing: 0.02em;
-    }
-}
-
-// Clean Post Styling (inspired by karpathy blog)
-.post-title,
-.page-title {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 2rem;
-    font-weight: 600;
-    line-height: 1.2;
-    margin-bottom: 1rem;
-    color: #222;
-    letter-spacing: normal;
-    
-    @media (max-width: 768px) {
-        font-size: 1.75rem;
-    }
-}
-
+// Small-caps style meta line (home entries + post pages)
+.entry-meta,
 .post-meta {
-    font-family: 'DM Sans', sans-serif;
-    margin-bottom: 1.5rem;
-    font-size: 0.9rem;
-    color: #666;
-    letter-spacing: normal;
-    
-    .post-date {
-        color: #374151;
-        font-weight: 500;
-        margin-right: 1rem;
-    }
-    
-    .post-categories a {
-        color: #6366f1;
+  color: $body-muted;
+  font-size: 0.72rem;
+  font-style: normal;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+
+  .entry-category {
+    color: $link-color;
+  }
+
+  a {
+    color: $link-color;
+  }
+}
+
+// Editorial post list on the home page
+.home-posts .home-post {
+  border-bottom: 1px solid $border-color;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+
+  &:last-child {
+    border-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .entry-title {
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0.4rem 0 0.5rem;
+
+    a {
+      color: $heading-color;
+
+      &:hover,
+      &:focus {
+        color: $link-color;
         text-decoration: none;
-        font-weight: 500;
-        margin-right: 0.5rem;
-        
-        &:hover {
-            text-decoration: underline;
-        }
+      }
     }
+  }
+
+  .entry-excerpt {
+    color: #5a4f44;
+    font-size: 0.95rem;
+    line-height: 1.65;
+    margin: 0;
+  }
+}
+
+// Post pages
+.post-meta {
+  margin-bottom: 2rem;
 }
 
 .post-body {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 1rem;
-    line-height: 1.5;
-    color: #333;
-    max-width: 720px;
-    margin: 0 auto;
-    letter-spacing: normal;
-    
-    @media (min-width: 1024px) {
-        max-width: 900px;
-    }
-    
-    @media (min-width: 768px) {
-        font-size: 0.9rem;
-    }
-    
-    h1, h2, h3, h4, h5, h6 {
-        font-family: 'DM Sans', sans-serif;
-        color: #222;
-        font-weight: 600;
-        margin-top: 1rem;
-        margin-bottom: 0.5rem;
-        line-height: 1.3;
-        letter-spacing: normal;
-    }
-    
-    h2 {
-        font-size: 1.25rem;
-        margin-top: 1.25rem;
-        font-weight: 600;
-    }
-    
-    h3 {
-        font-size: 1.125rem;
-        margin-top: 1rem;
-        font-weight: 600;
-    }
-    
-    h4 {
-        font-size: 1rem;
-        margin-top: 1rem;
-        font-weight: 600;
-    }
-    
-    p {
-        margin-bottom: 1rem;
-        
-        &:last-child {
-            margin-bottom: 0;
-        }
-    }
-    
-    ul, ol {
-        margin-bottom: 1rem;
-        padding-left: 1.5rem;
-        
-        li {
-            margin-bottom: 0.125rem;
-            line-height: 1.5;
-        }
-    }
-    
-    blockquote {
-        margin: 1rem 0;
-        padding-left: 1rem;
-        border-left: 3px solid #ddd;
-        color: #666;
-        font-style: italic;
-        
-        p {
-            margin-bottom: 0.5rem;
-        }
-    }
-    
-    img {
-        max-width: 100%;
-        height: auto;
-        margin: 1rem 0;
-        border-radius: 3px;
-    }
-    
-    code {
-        background: #f3f4f6;
-        padding: 0.125rem 0.25rem;
-        border-radius: 3px;
-        font-size: 0.875rem;
-        color: #1f2937;
-    }
-    
-    pre {
-        background: #1f2937;
-        color: #f9fafb;
-        padding: 1.5rem;
-        border-radius: 6px;
-        overflow-x: auto;
-        margin: 2rem 0;
-        
-        code {
-            background: transparent;
-            padding: 0;
-            color: inherit;
-            font-size: 0.875rem;
-        }
-    }
-    
-    table {
-        width: 100%;
-        border-collapse: collapse;
-        margin: 2rem 0;
-        
-        th, td {
-            padding: 0.75rem;
-            text-align: left;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        
-        th {
-            background: #f9fafb;
-            font-weight: 600;
-            color: #374151;
-        }
-    }
+  line-height: 1.75;
+
+  img {
+    border-radius: $border-radius;
+    margin: 1.5rem 0;
+  }
 }
 
-.content {
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem;
-    
-    @media (min-width: 1024px) {
-        max-width: 900px;
-    }
-    
-    @media (max-width: 768px) {
-        padding: 1.5rem 1rem;
-    }
+// Drop cap on the opening paragraph; opt out per-post with `dropcap: false`
+.dropcap > p:first-of-type::first-letter {
+  color: $link-color;
+  float: left;
+  font-family: $display-font-family;
+  font-size: 3.4em;
+  font-weight: 600;
+  line-height: 0.85;
+  padding: 0.05em 0.08em 0 0;
 }
 
-// Improved code blocks
-pre,
-code {
-    background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-    border-radius: 6px;
-    border: 1px solid #475569;
-}
-
-// Contemporary tags styling
+// Tags below posts: quiet #tag links
 .post-tags {
-    font-family: 'DM Sans', sans-serif;
-    margin-top: 2.5rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #e5e7eb;
-    
-    a {
-        display: inline-block;
-        color: #6b7280;
-        text-decoration: none;
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-right: 1rem;
-        margin-bottom: 0.5rem;
-        letter-spacing: 0.01em;
-        
-        &:before {
-            content: '#';
-            margin-right: 0.25rem;
-        }
-        
-        &:hover {
-            color: #6366f1;
-        }
+  > a,
+  > span {
+    color: $body-muted;
+    display: inline-block;
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+    margin-right: 1rem;
+    opacity: 1;
+    white-space: nowrap;
+
+    .icon {
+      display: none;
     }
+
+    &::before {
+      content: '#';
+    }
+
+    &:hover {
+      color: $link-color;
+      text-decoration: none;
+    }
+  }
 }
 
-// Clean page content styling (matches post styling)
-.page .content {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 1rem;
-    line-height: 1.5;
-    color: #333;
-    max-width: 720px;
-    margin: 0 auto;
-    letter-spacing: normal;
-    
-    @media (min-width: 1024px) {
-        max-width: 900px;
-    }
-    
-    @media (min-width: 768px) {
-        font-size: 0.9rem;
-    }
-    
-    h1, h2, h3, h4, h5, h6 {
-        font-family: 'DM Sans', sans-serif;
-        color: #222;
-        font-weight: 600;
-        margin-top: 1rem;
-        margin-bottom: 0.5rem;
-        line-height: 1.3;
-        letter-spacing: normal;
-    }
-    
-    h2 {
-        font-size: 1.25rem;
-        margin-top: 1.25rem;
-    }
-    
+// Related posts + tag page post lists (title with inline date)
+.related,
+.posts-for-tag {
+  h2 {
+    color: $body-muted;
+    font-family: $root-font-family;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .posts-list li {
+    margin-bottom: 1rem;
+
     h3 {
-        font-size: 1.125rem;
-        margin-top: 1rem;
-    }
-    
-    h4 {
-        font-size: 1rem;
-        margin-top: 1rem;
-    }
-    
-    p {
-        margin-bottom: 1rem;
-        
-        &:last-child {
-            margin-bottom: 0;
-        }
-    }
-    
-    ul, ol {
-        margin-bottom: 1rem;
-        padding-left: 1.5rem;
-        
-        li {
-            margin-bottom: 0.125rem;
-            line-height: 1.5;
-        }
-    }
-    
-    blockquote {
-        margin: 1rem 0;
-        padding-left: 1rem;
-        border-left: 3px solid #ddd;
-        color: #666;
-        font-style: italic;
-        
-        p {
-            margin-bottom: 0.5rem;
-        }
-    }
-    
-    img {
-        max-width: 100%;
-        height: auto;
-        margin: 1rem 0;
-        border-radius: 3px;
-    }
-    
-    a {
-        color: #6366f1;
-        text-decoration: none;
-        
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-    
-    .about-image {
-        display: block;
-        margin: 1rem auto;
-        max-width: 300px;
-        height: auto;
-        border-radius: 8px;
-        
-        @media (max-width: 768px) {
-            max-width: 250px;
-            margin: 0.75rem auto;
-        }
-    }
-}
+      font-size: 1.15rem;
+      margin: 0;
 
-// Contemporary related posts
-.related-posts {
-    margin-top: 3rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #e5e7eb;
-    
-    h2 {
-        font-family: 'DM Serif Display', serif;
-        font-size: 1.25rem;
-        color: #1f2937;
-        margin-bottom: 1.5rem;
+      a {
+        color: $heading-color;
+
+        &:hover,
+        &:focus {
+          color: $link-color;
+          text-decoration: none;
+
+          small {
+            color: $body-muted;
+          }
+        }
+      }
+
+      small {
+        font-family: $root-font-family;
         font-weight: 400;
-        letter-spacing: -0.015em;
+        letter-spacing: 0.06em;
+        margin-left: 0.5rem;
+        text-transform: uppercase;
+      }
     }
-    
-    .posts-list {
-        list-style: none;
-        padding: 0;
-        
-        li {
-            margin-bottom: 1.5rem;
-            
-            h3 {
-                font-family: 'DM Serif Display', serif;
-                font-size: 1.125rem;
-                margin: 0 0 0.25rem 0;
-                font-weight: 400;
-                letter-spacing: -0.01em;
-                
-                a {
-                    color: #1f2937;
-                    text-decoration: none;
-                    
-                    &:hover {
-                        color: #6366f1;
-                    }
-                }
-            }
-            
-            small {
-                font-family: 'DM Sans', sans-serif;
-                color: #6b7280;
-                font-size: 0.875rem;
-                font-weight: 500;
-                letter-spacing: 0.01em;
-            }
-        }
-    }
+  }
 }
 
-// Minimal category pages styling (inspired by karpathy.bearblog.dev)
-.container .posts-list {
-    list-style: none;
-    padding: 0;
-    margin-top: 1.5rem;
-    
-    li {
-        margin-bottom: 0.75rem;
-        display: flex;
-        align-items: baseline;
-        gap: 1rem;
-        
-        h3 {
-            font-family: 'DM Sans', sans-serif;
-            font-size: 0.95rem;
-            margin: 0;
-            font-weight: 500;
-            letter-spacing: -0.01em;
-            line-height: 1.4;
-            flex: 1;
-            
-            a {
-                color: #374151;
-                text-decoration: none;
-                
-                &:hover {
-                    color: #6366f1;
-                    text-decoration: underline;
-                }
-                
-                &:visited {
-                    color: #6b7280;
-                }
-            }
-        }
-        
-        small {
-            font-family: 'DM Sans', sans-serif;
-            color: #9ca3af;
-            font-size: 0.85rem;
-            font-weight: 400;
-            letter-spacing: 0.01em;
-            white-space: nowrap;
-            min-width: 100px;
-            text-align: left;
-        }
+// Category pages: date + title rows
+.category .posts-list li {
+  align-items: baseline;
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+
+  small {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    min-width: 6.5rem;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    font-family: $root-font-family;
+    font-size: 1.05rem;
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.4;
+    margin: 0;
+
+    a {
+      color: $body-color;
+
+      &:hover,
+      &:focus {
+        color: $link-color;
+        text-decoration: none;
+      }
     }
+  }
 }
 
-// Home page posts with excerpts
-.home-posts {
-    
-    .home-post {
-        margin-bottom: 2rem;
-        display: flex;
-        gap: 0.8rem;
-        
-        &:last-child {
-            margin-bottom: 0;
-        }
-        
-        // Mobile optimizations
-        @media (max-width: 768px) {
-            margin-bottom: 1rem;
-            gap: 0.5rem;
-            flex-direction: column;
-        }
-        
-        .home-post-meta {
-            min-width: 100px;
-            flex-shrink: 0;
-            
-            @media (max-width: 768px) {
-                min-width: auto;
-                margin-bottom: 0.25rem;
-            }
-            
-            small {
-                font-family: 'DM Sans', sans-serif;
-                color: #9ca3af;
-                font-size: 0.85rem;
-                font-weight: 400;
-                letter-spacing: 0.01em;
-                
-                @media (max-width: 768px) {
-                    font-size: 0.8rem;
-                    color: #6b7280;
-                }
-            }
-        }
-        
-        .home-post-content {
-            flex: 1;
-            
-            h3 {
-                font-family: 'DM Serif Display', serif;
-                font-size: 1rem;
-                margin: 0 0 0.5rem 0;
-                font-weight: 400;
-                letter-spacing: -0.015em;
-                line-height: 1.3;
-                
-                @media (max-width: 768px) {
-                    font-size: 1.1rem;
-                    margin: 0 0 0.5rem 0;
-                    line-height: 1.25;
-                }
-                
-                a {
-                    color: #1f2937;
-                    text-decoration: none;
-                    
-                    &:hover {
-                        color: #6366f1;
-                    }
-                    
-                    &:visited {
-                        color: #6b7280;
-                    }
-                }
-            }
-            
-            .home-post-excerpt {
-                font-family: 'DM Sans', sans-serif;
-                font-size: 0.9rem;
-                line-height: 1.4;
-                color: #6b7280;
-                margin-bottom: 0;
-                letter-spacing: -0.01em;
-                
-                a {
-                    color: inherit;
-                    text-decoration: none;
-                    
-                    &:hover {
-                        color: #4b5563;
-                        text-decoration: none;
-                    }
-                    
-                    &:visited {
-                        color: inherit;
-                    }
-                }
-                
-                @media (max-width: 768px) {
-                    font-size: 0.95rem;
-                    line-height: 1.5;
-                    color: #4b5563;
-                    
-                    a {
-                        &:hover {
-                            color: #374151;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
+// About page portrait
+.about-image {
+  border-radius: $border-radius;
+  display: block;
+  margin: 1.5rem auto;
+  max-width: 300px;
 
-// Mobile pagination button optimization
-.pagination {
-    // Apply modern border radius for all screen sizes
-    > a {
-        border-radius: 8px !important;
-    }
-    
-    // Desktop - elegant and compact
-    @media (min-width: 769px) {
-        > a {
-            width: auto !important;
-            max-width: none !important;
-            padding: 0.6rem 1.5rem !important;
-            font-size: 0.85rem;
-            display: inline-block;
-            min-width: 80px;
-        }
-    }
-    
-    // Mobile - larger touch targets
-    @media (max-width: 768px) {
-        > a {
-            width: auto !important;
-            max-width: none !important;
-            padding: 1rem 2.5rem !important;
-            font-size: 0.9rem;
-            display: inline-block;
-            min-width: 120px;
-        }
-    }
+  @media (max-width: 768px) {
+    max-width: 250px;
+  }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,72 +5,38 @@
 
 @import "hydeout";
 
-// Warm Editorial component layer
-// Base palette, type, and layout live in _sass/hydeout/*; this file only
-// styles the site-specific components (home list, post page, tags, etc.).
+// Warm editorial component layer
+// Base palette, type, and layout live in _sass/hydeout/*; this file styles the
+// site-specific components (home list, post page, tags, etc.).
 
 // Home intro
 .home-intro {
-  margin-bottom: 1.75rem;
-
-  .home-kicker {
-    align-items: center;
-    color: $link-color;
-    display: flex;
-    font-family: $root-font-family;
-    font-size: 0.72rem;
-    font-weight: 600;
-    gap: 0.6rem;
-    letter-spacing: 0.18em;
-    margin: 0 0 0.85rem;
-    text-transform: uppercase;
-
-    &::before {
-      background: $link-color;
-      content: '';
-      display: inline-block;
-      height: 1px;
-      width: 1.75rem;
-    }
-  }
+  margin-bottom: 2.5rem;
 
   h1 {
-    font-size: 2.5rem;
-    line-height: 1.1;
-    margin-bottom: 0.75rem;
+    font-size: 2.4rem;
+    line-height: 1.12;
+    margin-bottom: 0.6rem;
 
     @media (min-width: $large-breakpoint) {
-      font-size: 2.75rem;
+      font-size: 2.6rem;
     }
   }
 
   .home-tagline {
     color: $body-muted;
-    font-style: italic;
     margin: 0;
   }
 }
 
-// Flourish divider between the intro and the post list
-.ornament {
-  color: rgba($terracotta, 0.55);
-  font-size: 1.4rem;
-  line-height: 1;
-  margin: 0 0 2.75rem;
-  text-align: center;
-}
-
-// Small-caps style meta line (home entries + post pages)
+// Meta line (home entries + post pages)
 .entry-meta,
 .post-meta {
   color: $body-muted;
-  font-size: 0.72rem;
-  font-style: normal;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 0.8rem;
 
   .entry-category {
-    color: $link-color;
+    text-transform: capitalize;
   }
 
   a {
@@ -78,23 +44,9 @@
   }
 }
 
-// "Latest" pill on the lead entry
-.entry-flag {
-  background: $link-color;
-  border-radius: 999px;
-  color: $paper;
-  font-size: 0.62rem;
-  letter-spacing: 0.12em;
-  margin-right: 0.6rem;
-  padding: 0.15em 0.55em;
-  vertical-align: 0.08em;
-}
-
-// Editorial post list on the home page
+// Post list on the home page
 .home-posts .home-post {
   border-bottom: 1px solid $border-color;
-  display: flex;
-  gap: 1.25rem;
   margin-bottom: 2rem;
   padding-bottom: 2rem;
 
@@ -104,30 +56,10 @@
     padding-bottom: 0;
   }
 
-  // Hanging magazine-style index numeral
-  .entry-index {
-    color: rgba($terracotta, 0.5);
-    flex-shrink: 0;
-    font-family: $display-font-family;
-    font-feature-settings: 'tnum' 1;
-    font-size: 1.05rem;
-    font-weight: 600;
-    line-height: 1.9;
-    width: 1.6rem;
-
-    @media (min-width: $large-breakpoint) {
-      font-size: 1.15rem;
-    }
-  }
-
-  .entry-body {
-    min-width: 0;
-  }
-
   .entry-title {
-    font-size: 1.6rem;
+    font-size: 1.55rem;
     line-height: 1.2;
-    margin: 0.4rem 0 0.5rem;
+    margin: 0.35rem 0 0.5rem;
 
     a {
       color: $heading-color;
@@ -141,31 +73,8 @@
   }
 
   .entry-excerpt {
-    color: #5a4f44;
-    font-size: 0.95rem;
-    line-height: 1.65;
+    color: $body-color;
     margin: 0;
-  }
-
-  // Lead story: larger billing for the newest post
-  &.is-lead {
-    .entry-index {
-      line-height: 2.4;
-    }
-
-    .entry-title {
-      font-size: 2.1rem;
-      line-height: 1.12;
-
-      @media (min-width: $large-breakpoint) {
-        font-size: 2.35rem;
-      }
-    }
-
-    .entry-excerpt {
-      font-size: 1.05rem;
-      line-height: 1.7;
-    }
   }
 }
 
@@ -181,33 +90,6 @@
     border-radius: $border-radius;
     margin: 1.5rem 0;
   }
-
-  // Inline links: terracotta underline that wipes in on hover
-  p a,
-  li a {
-    background-image: linear-gradient($link-color, $link-color);
-    background-position: 0 1.15em;
-    background-repeat: no-repeat;
-    background-size: 0% 1px;
-    transition: background-size 0.3s ease;
-
-    &:hover,
-    &:focus {
-      background-size: 100% 1px;
-      text-decoration: none;
-    }
-  }
-}
-
-// Drop cap on the opening paragraph; opt out per-post with `dropcap: false`
-.dropcap > p:first-of-type::first-letter {
-  color: $link-color;
-  float: left;
-  font-family: $display-font-family;
-  font-size: 3.4em;
-  font-weight: 600;
-  line-height: 0.85;
-  padding: 0.05em 0.08em 0 0;
 }
 
 // Tags below posts: quiet #tag links
@@ -219,7 +101,6 @@
     font-size: 0.85rem;
     margin-bottom: 0.5rem;
     margin-right: 1rem;
-    opacity: 1;
     white-space: nowrap;
 
     .icon {
@@ -237,16 +118,11 @@
   }
 }
 
-// Related posts + tag page post lists (title with inline date)
+// Related posts + tag page post lists
 .related,
 .posts-for-tag {
   h2 {
-    color: $body-muted;
-    font-family: $root-font-family;
-    font-size: 0.8rem;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
+    font-size: 1.3rem;
   }
 
   .posts-list li {
@@ -271,11 +147,9 @@
       }
 
       small {
-        font-family: $root-font-family;
+        color: $body-muted;
         font-weight: 400;
-        letter-spacing: 0.06em;
         margin-left: 0.5rem;
-        text-transform: uppercase;
       }
     }
   }
@@ -289,18 +163,15 @@
   margin-bottom: 0.85rem;
 
   small {
+    color: $body-muted;
     flex-shrink: 0;
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
+    font-size: 0.8rem;
     min-width: 6.5rem;
-    text-transform: uppercase;
   }
 
   h3 {
-    font-family: $root-font-family;
-    font-size: 1.05rem;
+    font-size: 1.1rem;
     font-weight: 500;
-    letter-spacing: 0;
     line-height: 1.4;
     margin: 0;
 
@@ -331,38 +202,23 @@
 // ---------------------------------------------------------------------------
 // Phone optimizations
 //
-// Scoped to <= 40rem so the desktop (>= $large-breakpoint) and tablet layouts
-// are left exactly as-is. This block only refines the small-screen reading and
-// navigation experience: a stacked masthead, gentler type scale so long titles
-// don't fragment, tighter index numerals, and no accidental horizontal scroll.
+// Scoped to <= 40rem so the desktop and tablet layouts are left as-is: a
+// stacked masthead, gentler headline sizes, and no horizontal overflow.
 // ---------------------------------------------------------------------------
 $phone-breakpoint: 40rem;
 
 @media (max-width: $phone-breakpoint) {
-  // Two-row masthead: title, then a full-width nav with bigger tap targets
   .masthead {
     align-items: stretch;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.6rem;
     padding: 1rem 1.15rem 0.9rem;
   }
 
-  .masthead-nav {
-    gap: 0.2rem 1.3rem;
-
-    a {
-      // Taller hit area while keeping the underline tight to the text
-      padding-bottom: 0.4rem;
-      padding-top: 0.2rem;
-    }
-  }
-
-  // Tighter, more comfortable reading gutters
   .container {
     padding: 1.75rem 1.15rem 2.5rem;
   }
 
-  // Keep long titles, URLs, and inline code from forcing the page sideways
   .post-body,
   .entry-title,
   .entry-excerpt,
@@ -371,73 +227,19 @@ $phone-breakpoint: 40rem;
     overflow-wrap: break-word;
   }
 
-  // Home intro: smaller headline, less air before the list
-  .home-intro {
-    margin-bottom: 1.5rem;
-
-    h1 {
-      font-size: 2rem;
-    }
+  .home-intro h1 {
+    font-size: 2rem;
   }
 
-  .ornament {
-    margin-bottom: 2.25rem;
+  .home-posts .home-post .entry-title {
+    font-size: 1.35rem;
   }
 
-  // Tighten the hanging index numeral so titles keep their width
-  .home-posts .home-post {
-    gap: 0.85rem;
-
-    .entry-index {
-      font-size: 0.92rem;
-      line-height: 1.7;
-      width: 1.2rem;
-    }
-
-    .entry-title {
-      font-size: 1.4rem;
-    }
-
-    .entry-excerpt {
-      font-size: 0.95rem;
-    }
-
-    // Lead story stays the largest, but sized for a narrow column
-    &.is-lead {
-      .entry-index {
-        line-height: 2;
-      }
-
-      .entry-title {
-        font-size: 1.75rem;
-      }
-
-      .entry-excerpt {
-        font-size: 1rem;
-      }
-    }
+  .container > header h1,
+  .container > header h2 {
+    font-size: 1.85rem;
   }
 
-  // Post/page titles render in .container > header
-  .container > header {
-    margin-bottom: 1.25rem;
-
-    h1,
-    h2 {
-      font-size: 1.85rem;
-    }
-
-    &::after {
-      margin-top: 0.9rem;
-    }
-  }
-
-  // A smaller drop cap so it doesn't crowd a narrow measure
-  .dropcap > p:first-of-type::first-letter {
-    font-size: 2.8em;
-  }
-
-  // Roomier footer tap targets
   .site-footer .footer-links a {
     display: inline-block;
     padding: 0.3rem 0;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -327,3 +327,119 @@
     max-width: 250px;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Phone optimizations
+//
+// Scoped to <= 40rem so the desktop (>= $large-breakpoint) and tablet layouts
+// are left exactly as-is. This block only refines the small-screen reading and
+// navigation experience: a stacked masthead, gentler type scale so long titles
+// don't fragment, tighter index numerals, and no accidental horizontal scroll.
+// ---------------------------------------------------------------------------
+$phone-breakpoint: 40rem;
+
+@media (max-width: $phone-breakpoint) {
+  // Two-row masthead: title, then a full-width nav with bigger tap targets
+  .masthead {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem 1.15rem 0.9rem;
+  }
+
+  .masthead-nav {
+    gap: 0.2rem 1.3rem;
+
+    a {
+      // Taller hit area while keeping the underline tight to the text
+      padding-bottom: 0.4rem;
+      padding-top: 0.2rem;
+    }
+  }
+
+  // Tighter, more comfortable reading gutters
+  .container {
+    padding: 1.75rem 1.15rem 2.5rem;
+  }
+
+  // Keep long titles, URLs, and inline code from forcing the page sideways
+  .post-body,
+  .entry-title,
+  .entry-excerpt,
+  .post-title,
+  .page-title {
+    overflow-wrap: break-word;
+  }
+
+  // Home intro: smaller headline, less air before the list
+  .home-intro {
+    margin-bottom: 1.5rem;
+
+    h1 {
+      font-size: 2rem;
+    }
+  }
+
+  .ornament {
+    margin-bottom: 2.25rem;
+  }
+
+  // Tighten the hanging index numeral so titles keep their width
+  .home-posts .home-post {
+    gap: 0.85rem;
+
+    .entry-index {
+      font-size: 0.92rem;
+      line-height: 1.7;
+      width: 1.2rem;
+    }
+
+    .entry-title {
+      font-size: 1.4rem;
+    }
+
+    .entry-excerpt {
+      font-size: 0.95rem;
+    }
+
+    // Lead story stays the largest, but sized for a narrow column
+    &.is-lead {
+      .entry-index {
+        line-height: 2;
+      }
+
+      .entry-title {
+        font-size: 1.75rem;
+      }
+
+      .entry-excerpt {
+        font-size: 1rem;
+      }
+    }
+  }
+
+  // Post/page titles render in .container > header
+  .container > header {
+    margin-bottom: 1.25rem;
+
+    h1,
+    h2 {
+      font-size: 1.85rem;
+    }
+
+    &::after {
+      margin-top: 0.9rem;
+    }
+  }
+
+  // A smaller drop cap so it doesn't crowd a narrow measure
+  .dropcap > p:first-of-type::first-letter {
+    font-size: 2.8em;
+  }
+
+  // Roomier footer tap targets
+  .site-footer .footer-links a {
+    display: inline-block;
+    padding: 0.3rem 0;
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the dark-sidebar layout with a warm editorial design, restructures the home page into a maker's table of contents, and improves the post reading experience on desktop and phones.

## What the site looks like now

**Layout & navigation**
- Slim masthead (site title left, nav right) replaces the fixed dark sidebar; single centered reading column (42rem measure)
- Home page is a table of contents: intro, a "Things I build & run" section surfacing live projects (Story to Manga Machine, Tambourine Voice, the Pokémon TCG event hub, the TCG idle game — entries editable in `_data/projects.yml`), then the writing list
- Posts end with quiet Older/Newer navigation (skips `hidden: true` drafts) followed by Related Posts
- Site footer with email/GitHub/LinkedIn/Tags links; RSS link removed from the nav (feed itself unchanged)

**Type & color**
- Fraunces for display, Source Serif 4 for body; cream paper `#faf6f0` with warm ink tones
- Terracotta accent `#b23c0a` — deepened from the original `#c2410c` for WCAG AA headroom (5.5:1 against the paper; all text pairings verified AA)

**Reading experience**
- Post meta shows date, reading time, and category
- Image captions (authored as an italic line under an image) render as centered figure captions
- On large screens, images break out gently past the text column to ~50rem via `:has()` (graceful fallback to column width)
- Phone block (≤40rem): stacked masthead, adjusted type scale, no horizontal overflow

**Untouched**
- `/pokemon/` and `/tcg-idle-game/` standalone subprojects
- Feed, SEO tags, analytics, all post content

## Notes for review

- History includes an experimental broadsheet reskin and its revert (kept for the record) — **squash-merge intended** so `master` gets one clean commit
- Net diff removes more than it adds (the old sidebar CSS carried a lot of weight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZNJDzsA3HweT7593JRPCC