### PR TITLE
Add playful details to the editorial design

### DIFF
--- a/_includes/font-includes.html
+++ b/_includes/font-includes.html
@@ -5,4 +5,4 @@ different fonts as applicable.
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,WONK@0,9..144,400..700,0..1;1,9..144,400..700,0..1&family=Source+Serif+4:ital,opsz,wght@0,8..60,400..600;1,8..60,400..600&display=swap" />

--- a/_includes/svg/squiggle.svg
+++ b/_includes/svg/squiggle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 8" fill="none" aria-hidden="true" focusable="false"><path d="M2 5 Q 9 1 16 5 T 30 5 T 44 5 T 58 5 T 72 5 T 86 5 T 100 5 T 114 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -12,6 +12,7 @@ layout: default
     {% if site.data.projects %}
       <section class="home-projects">
         <h2 class="home-section-title">Things I build &amp; run</h2>
+        <span class="squiggle">{% include svg/squiggle.svg %}</span>
         <ul class="projects-list">
           {% for project in site.data.projects %}
             <li>
@@ -31,6 +32,7 @@ layout: default
 
   {% if page.url == "/" %}
     <h2 class="home-section-title">Writing</h2>
+    <span class="squiggle">{% include svg/squiggle.svg %}</span>
   {% endif %}
 
   <div class="home-posts">

--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -32,6 +32,11 @@ section {
   display: block;
 }
 
+::selection {
+  background: #f3d9c6; // solid terracotta tint of $paper; alpha blends inconsistently across browsers
+  color: $ink;
+}
+
 // No `:visited` state is required by default (browsers will use `a`)
 a {
   color: $link-color;

--- a/_sass/hydeout/_masthead.scss
+++ b/_sass/hydeout/_masthead.scss
@@ -22,6 +22,7 @@
   color: $heading-color;
   font-family: $display-font-family;
   font-size: 1.4rem;
+  font-variation-settings: 'WONK' 1;
   font-weight: 600;
   letter-spacing: -0.01em;
   white-space: nowrap;
@@ -47,7 +48,9 @@
     &:hover,
     &:focus {
       color: $link-color;
-      text-decoration: none;
+      text-decoration: underline wavy;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 4px;
     }
 
     &.active {

--- a/_sass/hydeout/_tags.scss
+++ b/_sass/hydeout/_tags.scss
@@ -14,6 +14,15 @@
   padding-right: 0.6em;
 }
 
+// Rotate pill accents; purely decorative, no color carries meaning
+.tags-list a:nth-child(3n + 2) .tag-count {
+  background: $mustard;
+}
+
+.tags-list a:nth-child(3n) .tag-count {
+  background: $teal;
+}
+
 .tags-list a:hover {
   opacity: 1;
   text-decoration: none;

--- a/_sass/hydeout/_type.scss
+++ b/_sass/hydeout/_type.scss
@@ -18,6 +18,12 @@ h6,
   text-rendering: optimizeLegibility;
 }
 
+// Fraunces' wonky alternates, saved for the biggest display moments only
+h1,
+.site-title {
+  font-variation-settings: 'WONK' 1;
+}
+
 h1 {
   font-size: 2rem;
 }

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -5,6 +5,8 @@ $ink-soft: #2b241d !default; // body ink
 $ink-muted: #6e6258 !default; // meta / muted text
 $terracotta: #b23c0a !default; // accent (deepened slightly for AA headroom)
 $terracotta-dark: #9a3412 !default; // inline code accent
+$mustard: #9a6d0b !default; // warm ochre; playful secondary accent
+$teal: #2b6e6a !default; // muted pine; the single cool note
 $hairline: #e7decf !default; // warm hairline borders
 $wash: #f4eee3 !default; // code blocks / tinted panels
 $wash-strong: #f1eae0 !default; // table headers

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -36,8 +36,23 @@
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.12em;
-  margin: 0 0 1.25rem;
+  margin: 0 0 0.4rem;
   text-transform: uppercase;
+}
+
+// Hand-drawn squiggle accenting each section label
+.squiggle {
+  color: $terracotta;
+  display: block;
+  margin: 0 0 1.25rem;
+  opacity: 0.7;
+  width: 4.5rem;
+
+  svg {
+    display: block;
+    height: auto;
+    width: 100%;
+  }
 }
 
 // Things I build & run
@@ -70,6 +85,17 @@
       color: $link-color;
       text-decoration: none;
     }
+  }
+
+  // Decorative accent rotation on hover only; resting state stays quiet
+  li:nth-child(3n + 2) a:hover,
+  li:nth-child(3n + 2) a:focus {
+    color: $mustard;
+  }
+
+  li:nth-child(3n) a:hover,
+  li:nth-child(3n) a:focus {
+    color: $teal;
   }
 
   .project-blurb {
@@ -138,6 +164,20 @@
 // Post pages
 .post-meta {
   margin-bottom: 2rem;
+}
+
+// Content links get a draw-in underline instead of the theme's instant one
+.post-body a:not([href^='#fn']) {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 1px;
+
+  &:hover,
+  &:focus {
+    background-size: 100% 1px;
+    text-decoration: none;
+  }
 }
 
 .post-body {
@@ -327,6 +367,53 @@
 
   @media (max-width: 768px) {
     max-width: 250px;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Micro-motion
+//
+// All motion opts in via no-preference so reduced-motion users get the plain
+// static design with zero overrides.
+// ---------------------------------------------------------------------------
+@media (prefers-reduced-motion: no-preference) {
+  .home-projects li a {
+    transition: transform 160ms ease, color 160ms ease;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-2px) rotate(-0.5deg);
+    }
+  }
+
+  .post-body a:not([href^='#fn']) {
+    transition: background-size 220ms ease;
+  }
+
+  @keyframes home-rise {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .home .home-intro {
+    animation: home-rise 0.45s ease-out both;
+  }
+
+  .home .home-projects {
+    animation: home-rise 0.45s ease-out 0.08s both;
+  }
+
+  .home .home-posts,
+  .home .content > .home-section-title,
+  .home .content > .squiggle {
+    animation: home-rise 0.45s ease-out 0.16s both;
   }
 }
 


### PR DESCRIPTION
Season the calm warm-editorial look with subtle personality:

- Enable Fraunces' WONK axis for the site title and h1s (wonky
  hand-cut letterforms), requesting the axis from Google Fonts
- Add mustard and teal secondary accents: rotating tag pill colors,
  rotating project hover colors, terracotta-tinted text selection
- Add a hand-drawn squiggle divider under home section labels and a
  wavy hover underline on the masthead nav
- Add micro-motion behind prefers-reduced-motion: project links lift
  and tilt on hover, post links get a draw-in underline, homepage
  sections fade in with a gentle stagger

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EXC5H9M88N8ZWHDZZpNTiF